### PR TITLE
feat: leave management system

### DIFF
--- a/.opencode/skills/close-prd/SKILL.md
+++ b/.opencode/skills/close-prd/SKILL.md
@@ -1,0 +1,110 @@
+---
+name: close-prd
+description: Reconcile and close a PRD issue after all sub-issues are complete. Fetches the PRD issue, verifies sub-issues are closed, spot-checks the implementation against the original PRD intent, posts a reconciliation comment, and closes the issue. Use when user says "close prd #N", "reconcile prd #N", or "wrap up issue #N".
+---
+
+# Skill: close-prd
+
+Given a PRD GitHub issue number, verify all work is complete, reconcile the implementation against the original intent, and close the issue.
+
+## Process
+
+### 1. Fetch the PRD issue
+
+```bash
+gh issue view <number> --comments
+```
+
+Read the full issue body and all comments. Extract:
+- **User Stories** — the numbered list of stories the feature was meant to deliver
+- **Implementation Decisions** — the modules, API contracts, schema changes, and architectural decisions
+- **Testing Decisions** — what was expected to be tested
+- **Out of Scope** — what was explicitly excluded (do not flag these as gaps)
+- **Sub-issue references** — scan the body and all comments for `#N` issue links created by the `to-issues` skill
+
+### 2. Discover and verify sub-issues
+
+For each `#N` reference found in step 1:
+
+```bash
+gh issue view <N>
+```
+
+Collect the state (`open` / `closed`) and title of each sub-issue.
+
+**If any sub-issues are still open:**
+- List them clearly for the user with their titles and URLs
+- Ask: "The following sub-issues are still open. Do you want to proceed with closing the PRD anyway?"
+- Wait for explicit confirmation before continuing
+- If the user says no, stop here and remind them to finish those issues first
+
+### 3. Spot-check the implementation
+
+Explore only what is relevant to the PRD's **Implementation Decisions** section. Do NOT do a full repo scan.
+
+For each module or layer mentioned in Implementation Decisions:
+- Use Glob and Grep to locate the relevant files
+- Read the key sections to confirm the feature exists and broadly matches intent
+- Note any obvious deviations, missing pieces, or things that were implemented differently than planned
+
+You are not doing a code review — you are confirming the feature landed. Keep this step focused.
+
+### 4. Reconcile against user stories
+
+Go through each numbered user story from the PRD and assess:
+
+- ✅ **Met** — the story is clearly satisfied by the implementation
+- ⚠️ **Partially met** — the story is addressed but with caveats or deviations
+- ❌ **Not met** — no implementation found for this story (and it was not in Out of Scope)
+
+For each ⚠️ or ❌ story, note what is missing or different and whether it warrants a follow-up issue.
+
+### 5. Post a reconciliation comment
+
+Post a comment on the PRD issue summarising the outcome:
+
+```bash
+gh issue comment <number> --body "..."
+```
+
+Use this comment template:
+
+```
+## Reconciliation Summary
+
+All sub-issues have been completed and the implementation has been reviewed against the original PRD.
+
+### Sub-issues
+
+| Issue | Title | Status |
+|-------|-------|--------|
+| #N    | ...   | ✅ Closed |
+
+### User Story Coverage
+
+| # | Story | Status | Notes |
+|---|-------|--------|-------|
+| 1 | As a ... | ✅ Met | |
+| 2 | As a ... | ⚠️ Partial | <reason> |
+
+### Deviations from Original Plan
+
+<List any implementation decisions that changed during execution, and why. If none, write "None — implementation matched the plan.">
+
+### Follow-up Issues
+
+<List any gaps that warrant new issues. If none, write "None.">
+
+### Verification
+
+Sub-issues closed: N/N
+User stories met: N/N (N partial, N not met)
+```
+
+### 6. Close the PRD issue
+
+```bash
+gh issue close <number> --comment "Closing — all sub-issues complete and reconciliation posted above."
+```
+
+Do NOT close the issue before posting the reconciliation comment in step 5.

--- a/.opencode/skills/grill-me/SKILL.md
+++ b/.opencode/skills/grill-me/SKILL.md
@@ -11,3 +11,9 @@ If a question can be answered by exploring the codebase, explore
 the codebase instead.
 
 For each question, provide your recommended answer.
+
+Once all branches of the decision tree are resolved and we have reached
+a shared understanding, present the full plan back to the user as a
+structured summary (goals, decisions made, open questions if any, and
+proposed implementation steps). Wait for explicit approval before
+proceeding to implementation.

--- a/.opencode/skills/work-issue/SKILL.md
+++ b/.opencode/skills/work-issue/SKILL.md
@@ -1,0 +1,97 @@
+---
+name: work-issue
+description: Implement a GitHub issue end-to-end. Provide an issue number and the agent fetches the issue, explores the codebase, plans the work, implements it, verifies it, and posts a completion comment. Use when user says "work on issue #N", "implement issue #N", or "fix issue #N".
+---
+
+# Skill: work-issue
+
+Given a GitHub issue number, implement it fully — schema, backend, frontend, tests — following all project conventions from `AGENTS.md`.
+
+## Process
+
+### 1. Fetch the issue
+
+```bash
+gh issue view <number> --comments
+```
+
+Read the full issue body and all comments. Identify:
+- **What to build** (acceptance criteria)
+- **Blocked by** (do not start if blockers are open — inform the user)
+- **Parent issue** (for additional context; fetch it too if present)
+
+### 2. Explore the codebase
+
+Explore only what is relevant to the issue. Use Glob and Grep to find affected files. Read the files you will modify. Do NOT explore the entire repo.
+
+Identify all files that need to change across every layer:
+- Prisma schema / migrations
+- `libs/feature` services and modules
+- `libs/shared` wire types and permissions
+- `apps/api` controllers, DTOs, integration specs
+- `apps/web` API clients, queries, components, pages, routes
+
+### 3. Plan with TodoWrite
+
+Break the work into atomic tasks and add them to the todo list **before writing any code**. Use the implementation order from `AGENTS.md`:
+
+1. Shared types (`libs/shared`)
+2. Schema + migration (if needed)
+3. Backend service (`libs/feature`)
+4. Backend controller + DTOs (`apps/api`)
+5. Backend tests
+6. Frontend API client + queries (`apps/web`)
+7. Frontend components + pages (`apps/web`)
+8. Lint + typecheck + build verification
+
+Mark each todo `in_progress` when you start it and `completed` immediately when done.
+
+### 4. Implement
+
+Follow all conventions from `AGENTS.md`:
+
+- **Services never receive or return DTOs** — mapping happens only in the controller.
+- **Wire types** live in `libs/shared/src/models.ts` (plain string unions, no Prisma enums).
+- **DTOs** live in `apps/api/src/app/<entity>/dto/` and never leave the API layer.
+- **Soft deletes**: always filter `deletedAt: null`.
+- **Permissions**: guard routes with `@RequirePermission()` using constants from `libs/shared`.
+- **Radix UI**: never use `value=""` on `SelectItem` — use a sentinel string.
+- **No modals for CRUD**: use dedicated pages for Create/Update; modals only for Delete confirmation.
+- **Nx generators**: prefer generators over hand-written files; always `--dry-run` first.
+
+### 5. Verify
+
+Run in this order, fixing any failures before moving on:
+
+```bash
+# Lint
+npx nx lint <affected-project>
+
+# Type check
+npx nx run-many -t typecheck
+
+# Unit tests (if service was modified)
+npx nx test feature --testFile=<path>
+
+# Integration tests (if controller was modified)
+npx nx test api --testFile=<path>
+
+# Build
+npx nx build <affected-project>
+```
+
+### 6. Post a completion comment
+
+When all acceptance criteria are met and verification passes, post a comment on the issue:
+
+```bash
+gh issue comment <number> --body "..."
+```
+
+The comment must include:
+- A brief summary of what was implemented.
+- Which acceptance criteria are now met (tick each one).
+- Any deviations from the original plan and why.
+- Verification output (lint/typecheck/test/build pass confirmation).
+
+Do NOT close the issue — leave that to the human reviewer.

--- a/apps/api/src/app/leave-balance/leave-balance.integration.spec.ts
+++ b/apps/api/src/app/leave-balance/leave-balance.integration.spec.ts
@@ -1,0 +1,69 @@
+import { INestApplication } from '@nestjs/common';
+import supertest from 'supertest';
+import { Role } from '@ube-hr/backend';
+import { createTestApp } from '../../../test/helpers/app';
+import { truncateAll, seedDefaultPermissions } from '../../../test/helpers/db';
+import { seedAndLogin } from '../../../test/helpers/seed';
+
+describe('LeaveBalance config (integration)', () => {
+  let app: INestApplication;
+  let request: ReturnType<typeof supertest>;
+  let adminToken: string;
+
+  beforeAll(async () => {
+    app = await createTestApp();
+    request = supertest(app.getHttpServer());
+  });
+
+  afterAll(() => app.close());
+
+  beforeEach(async () => {
+    await truncateAll(app);
+    await seedDefaultPermissions(app);
+    const { token } = await seedAndLogin(app, request, {
+      email: 'admin@test.com',
+      role: Role.ADMIN,
+    });
+    adminToken = token;
+  });
+
+  describe('PUT /api/leave-balance/config/:type', () => {
+    it('returns 401 when unauthenticated', async () => {
+      await request
+        .put('/api/leave-balance/config/ANNUAL')
+        .send({ monthlyRate: 1 })
+        .expect(401);
+    });
+
+    it.each(['MATERNITY', 'PATERNITY', 'BEREAVEMENT'])(
+      'returns 400 for manual leave type %s',
+      async (type) => {
+        await request
+          .put(`/api/leave-balance/config/${type}`)
+          .set('Authorization', `Bearer ${adminToken}`)
+          .send({ monthlyRate: 1 })
+          .expect(400);
+      },
+    );
+
+    it('returns 200 for ANNUAL', async () => {
+      const res = await request
+        .put('/api/leave-balance/config/ANNUAL')
+        .set('Authorization', `Bearer ${adminToken}`)
+        .send({ monthlyRate: 2 })
+        .expect(200);
+
+      expect(res.body).toMatchObject({ leaveType: 'ANNUAL', monthlyRate: 2 });
+    });
+
+    it('returns 200 for SICK', async () => {
+      const res = await request
+        .put('/api/leave-balance/config/SICK')
+        .set('Authorization', `Bearer ${adminToken}`)
+        .send({ monthlyRate: 1 })
+        .expect(200);
+
+      expect(res.body).toMatchObject({ leaveType: 'SICK', monthlyRate: 1 });
+    });
+  });
+});

--- a/apps/web/src/features/leave-balance/components/AccrualConfigSection.tsx
+++ b/apps/web/src/features/leave-balance/components/AccrualConfigSection.tsx
@@ -15,6 +15,8 @@ const ACCRUAL_TYPES = [
   'BEREAVEMENT',
 ];
 
+const MANUAL_ACCRUAL_TYPES = new Set(['MATERNITY', 'PATERNITY', 'BEREAVEMENT']);
+
 export function AccrualConfigSection() {
   const { data: configs, isLoading } = useAccrualConfigs();
   const update = useUpdateAccrualConfig();
@@ -86,31 +88,39 @@ export function AccrualConfigSection() {
                 <td className="px-4 py-3 font-medium">
                   {LEAVE_TYPE_LABELS[type]}
                 </td>
-                <td className="px-4 py-3">
-                  <Input
-                    type="number"
-                    min="0"
-                    step="0.01"
-                    className="h-8 w-32"
-                    value={getRate(type)}
-                    onChange={(e) =>
-                      setEditRates((prev) => ({
-                        ...prev,
-                        [type]: e.target.value,
-                      }))
-                    }
-                  />
-                </td>
-                <td className="px-4 py-3">
-                  <Button
-                    size="sm"
-                    variant="outline"
-                    onClick={() => handleSave(type)}
-                    disabled={update.isPending}
-                  >
-                    Save
-                  </Button>
-                </td>
+                {MANUAL_ACCRUAL_TYPES.has(type) ? (
+                  <td className="px-4 py-3 text-muted-foreground italic" colSpan={2}>
+                    Manual Assignment Only
+                  </td>
+                ) : (
+                  <>
+                    <td className="px-4 py-3">
+                      <Input
+                        type="number"
+                        min="0"
+                        step="0.01"
+                        className="h-8 w-32"
+                        value={getRate(type)}
+                        onChange={(e) =>
+                          setEditRates((prev) => ({
+                            ...prev,
+                            [type]: e.target.value,
+                          }))
+                        }
+                      />
+                    </td>
+                    <td className="px-4 py-3">
+                      <Button
+                        size="sm"
+                        variant="outline"
+                        onClick={() => handleSave(type)}
+                        disabled={update.isPending}
+                      >
+                        Save
+                      </Button>
+                    </td>
+                  </>
+                )}
               </tr>
             ))}
           </tbody>

--- a/libs/feature/src/auth/auth.service.ts
+++ b/libs/feature/src/auth/auth.service.ts
@@ -58,7 +58,11 @@ export class AuthService {
   }
 
   async logout(userId: number) {
-    await this.usersService.incrementTokenVersion(userId);
+    try {
+      await this.usersService.incrementTokenVersion(userId);
+    } catch {
+      // User no longer exists (e.g. deleted or DB refreshed) — session is already invalid
+    }
   }
 
   async impersonate(adminId: number, targetUserId: number) {

--- a/libs/feature/src/leave-balance/leave-balance.service.spec.ts
+++ b/libs/feature/src/leave-balance/leave-balance.service.spec.ts
@@ -1,0 +1,116 @@
+import { BadRequestException } from '@nestjs/common';
+import { Test } from '@nestjs/testing';
+import { PrismaService, LeaveType } from '@ube-hr/backend';
+import { LeaveBalanceService } from './leave-balance.service';
+
+const createPrismaMock = () => ({
+  leaveAccrualConfig: {
+    upsert: jest.fn(),
+    findMany: jest.fn(),
+  },
+  leaveBalance: {
+    findUnique: jest.fn(),
+    findMany: jest.fn(),
+    upsert: jest.fn(),
+    updateMany: jest.fn(),
+    count: jest.fn(),
+  },
+  leaveBalanceAudit: { create: jest.fn(), findMany: jest.fn() },
+  user: { findUnique: jest.fn(), findMany: jest.fn() },
+  $transaction: jest.fn(),
+});
+
+describe('LeaveBalanceService', () => {
+  let service: LeaveBalanceService;
+  let prisma: ReturnType<typeof createPrismaMock>;
+
+  beforeEach(async () => {
+    prisma = createPrismaMock();
+    const module = await Test.createTestingModule({
+      providers: [
+        LeaveBalanceService,
+        { provide: PrismaService, useValue: prisma },
+      ],
+    }).compile();
+    service = module.get(LeaveBalanceService);
+  });
+
+  afterEach(() => jest.clearAllMocks());
+
+  describe('upsertConfig', () => {
+    it.each([
+      [LeaveType.MATERNITY],
+      [LeaveType.PATERNITY],
+      [LeaveType.BEREAVEMENT],
+    ])('throws BadRequestException for %s', async (leaveType) => {
+      await expect(service.upsertConfig(leaveType, 1)).rejects.toThrow(BadRequestException);
+      expect(prisma.leaveAccrualConfig.upsert).not.toHaveBeenCalled();
+    });
+
+    it('accepts ANNUAL and delegates to prisma', async () => {
+      prisma.leaveAccrualConfig.upsert.mockResolvedValue({
+        id: 1,
+        leaveType: LeaveType.ANNUAL,
+        monthlyRate: 2,
+        daysPerYear: 24,
+        carryOverLimit: 5,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      });
+      const result = await service.upsertConfig(LeaveType.ANNUAL, 2);
+      expect(result.leaveType).toBe(LeaveType.ANNUAL);
+      expect(prisma.leaveAccrualConfig.upsert).toHaveBeenCalledTimes(1);
+    });
+
+    it('accepts SICK and delegates to prisma', async () => {
+      prisma.leaveAccrualConfig.upsert.mockResolvedValue({
+        id: 2,
+        leaveType: LeaveType.SICK,
+        monthlyRate: 1,
+        daysPerYear: 12,
+        carryOverLimit: 3,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      });
+      const result = await service.upsertConfig(LeaveType.SICK, 1);
+      expect(result.leaveType).toBe(LeaveType.SICK);
+      expect(prisma.leaveAccrualConfig.upsert).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('runMonthlyAccrual', () => {
+    it('skips configs whose leaveType is not in VALID_ACCRUAL_TYPES', async () => {
+      prisma.leaveAccrualConfig.findMany.mockResolvedValue([
+        { leaveType: LeaveType.MATERNITY, monthlyRate: 1 },
+        { leaveType: LeaveType.PATERNITY, monthlyRate: 1 },
+        { leaveType: LeaveType.BEREAVEMENT, monthlyRate: 1 },
+      ]);
+      prisma.user.findMany.mockResolvedValue([{ id: 1 }]);
+
+      const result = await service.runMonthlyAccrual();
+
+      expect(result.processed).toBe(0);
+      expect(result.skipped).toBe(3);
+      expect(prisma.$transaction).not.toHaveBeenCalled();
+    });
+
+    it('processes ANNUAL and SICK configs but skips manual types', async () => {
+      prisma.leaveAccrualConfig.findMany.mockResolvedValue([
+        { leaveType: LeaveType.ANNUAL, monthlyRate: 2 },
+        { leaveType: LeaveType.MATERNITY, monthlyRate: 1 },
+      ]);
+      prisma.user.findMany.mockResolvedValue([{ id: 1 }]);
+      prisma.leaveBalance.findUnique.mockResolvedValue(null);
+      prisma.$transaction.mockImplementation((fn: (tx: typeof prisma) => Promise<void>) =>
+        fn(prisma),
+      );
+      prisma.leaveBalance.upsert.mockResolvedValue({});
+      prisma.leaveBalanceAudit.create.mockResolvedValue({});
+
+      const result = await service.runMonthlyAccrual();
+
+      expect(result.processed).toBe(1);
+      expect(result.skipped).toBe(1);
+    });
+  });
+});

--- a/libs/feature/src/leave-balance/leave-balance.service.ts
+++ b/libs/feature/src/leave-balance/leave-balance.service.ts
@@ -50,13 +50,7 @@ export interface AllBalancesQuery {
   pageSize?: string | number;
 }
 
-const VALID_ACCRUAL_TYPES: LeaveType[] = [
-  LeaveType.ANNUAL,
-  LeaveType.SICK,
-  LeaveType.MATERNITY,
-  LeaveType.PATERNITY,
-  LeaveType.BEREAVEMENT,
-];
+const VALID_ACCRUAL_TYPES: LeaveType[] = [LeaveType.ANNUAL, LeaveType.SICK];
 
 @Injectable()
 export class LeaveBalanceService {
@@ -263,6 +257,10 @@ export class LeaveBalanceService {
     let skipped = 0;
 
     for (const config of configs) {
+      if (!VALID_ACCRUAL_TYPES.includes(config.leaveType)) {
+        skipped++;
+        continue;
+      }
       for (const user of users) {
         const balance = await this.prisma.leaveBalance.findUnique({
           where: {

--- a/libs/feature/src/users/users.service.ts
+++ b/libs/feature/src/users/users.service.ts
@@ -374,11 +374,15 @@ export class UsersService {
   }
 
   async incrementTokenVersion(id: number): Promise<number> {
-    const user = await this.prisma.user.update({
-      where: { id },
-      data: { refreshTokenVersion: { increment: 1 } },
-    });
-    return user.refreshTokenVersion;
+    try {
+      const user = await this.prisma.user.update({
+        where: { id, deletedAt: null },
+        data: { refreshTokenVersion: { increment: 1 } },
+      });
+      return user.refreshTokenVersion;
+    } catch {
+      throw new NotFoundException('User not found');
+    }
   }
 
   async updateProfilePicture(

--- a/prisma/migrations/20260502222951_remove_manual_leave_accrual_configs/migration.sql
+++ b/prisma/migrations/20260502222951_remove_manual_leave_accrual_configs/migration.sql
@@ -1,0 +1,3 @@
+-- Remove accrual configs for manual leave types (MATERNITY, PATERNITY, BEREAVEMENT).
+-- These types are granted manually and should never be processed by the monthly accrual job.
+DELETE FROM `LeaveAccrualConfig` WHERE `leaveType` IN ('MATERNITY', 'PATERNITY', 'BEREAVEMENT');

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -78,6 +78,24 @@ type UserSeed = {
 };
 
 const SEED_USERS: UserSeed[] = [
+  // Named dev/demo accounts (easy to remember)
+  { email: 'superadmin@ube-hr.com', name: 'Super Admin', role: Role.SUPER_ADMIN },
+  { email: 'admin@ube-hr.com', name: 'Admin', role: Role.ADMIN },
+  {
+    email: 'manager@ube-hr.com',
+    name: 'Manager',
+    role: Role.MANAGER,
+    dept: 'Engineering',
+    position: 'Senior Software Engineer',
+  },
+  {
+    email: 'user@ube-hr.com',
+    name: 'User',
+    role: Role.USER,
+    dept: 'Engineering',
+    position: 'Software Engineer',
+  },
+
   // Super admin — no dept
   {
     email: 'super.admin@example.com',
@@ -221,6 +239,26 @@ const SEED_USERS: UserSeed[] = [
 ];
 
 async function main() {
+  const refresh = process.argv.includes('--refresh');
+
+  if (refresh) {
+    console.log('--refresh: truncating all tables...');
+    await prisma.membership.deleteMany();
+    await prisma.team.deleteMany();
+    await prisma.rolePermission.deleteMany();
+    await prisma.leaveApprovalStep.deleteMany();
+    await prisma.leaveRequest.deleteMany();
+    await prisma.leaveBalanceAudit.deleteMany();
+    await prisma.leaveBalance.deleteMany();
+    await prisma.leaveAccrualConfig.deleteMany();
+    await prisma.publicHoliday.deleteMany();
+    await prisma.department.updateMany({ data: { headId: null } });
+    await prisma.user.deleteMany();
+    await prisma.department.deleteMany();
+    await prisma.position.deleteMany();
+    console.log('Truncation complete.\n');
+  }
+
   // 1. Seed role permissions
   for (const [role, permissions] of Object.entries(
     DEFAULT_ROLE_PERMISSIONS,
@@ -336,6 +374,8 @@ async function main() {
         'carol.white@example.com',
         'david.lee@example.com',
         'ethan.nguyen@example.com',
+        'manager@ube-hr.com',
+        'user@ube-hr.com',
       ],
     },
     {


### PR DESCRIPTION
## Summary

Full-stack leave management feature including leave requests, balances, accruals, holidays, and approval workflows.

## What's Changed

### New Features

- **Leave Requests**: Employees can file leave requests (full-day, half-day AM/PM). Managers and admins can approve or reject with a reason. Leaves deduct from the employee's balance.
- **Leave Balances**: Per-user leave balance tracking with manual grant/adjustment by admins. Configurable accrual rules (monthly/annual rate, max carryover, proration).
- **Leave Accrual**: Automated accrual via BullMQ worker job (`leave.accrue`). Cron-triggered monthly; admins can manually trigger a run. Accrual respects each user's config and caps carryover.
- **Holidays**: CRUD management for public holidays. Holiday dates are excluded from leave day counting.
- **Approval Queue**: Dedicated page for managers/admins to review pending leave requests.

### Backend

- `libs/feature/src/leaves/` — `LeavesService` with full approval workflow, balance deduction, and conflict/overlap detection.
- `libs/feature/src/leave-balance/` — `LeaveBalanceService` with accrual logic, grant, and config management.
- `libs/feature/src/leave-accrual/` — `LeaveAccrualService` + `LeaveAccrualCronService` for scheduled and on-demand accrual.
- `libs/feature/src/holidays/` — `HolidaysService` for public holiday CRUD.
- New controllers: `leaves`, `leave-balance`, `leave-accruals`, `holidays`.
- New Prisma models: `Leave`, `LeaveBalance`, `LeaveAccrualConfig`, `Holiday` (with 5 migrations).
- Redis-backed `CacheService` in `libs/backend` for permission caching.
- BullMQ worker processor in `apps/worker/src/app/leave/` for async accrual processing.

### Frontend

- **Pages**: `LeavesPage`, `FileLeave`, `LeaveDetailPage`, `ApprovalQueuePage`, `LeaveBalancePage` (admin), `HolidaysPage`, `CreateHolidayPage`, `HolidayDetailPage`.
- **Features**: `leaves`, `leave-balance`, `holidays` feature modules with `.api.ts`, `.queries.ts`, and components.
- Routes registered in `app.tsx` behind `<RequirePermission>` guards.
- Nav links added to `AuthLayout`.

### Permissions

- New permissions: `leave:read`, `leave:create`, `leave:approve`, `leave:reject`, `leave:cancel`, `leave-balance:read`, `leave-balance:manage`, `leave-accrual:trigger`, `holiday:read`, `holiday:manage`.
- Default role assignments updated in `libs/shared/src/permissions.ts`.

### Tests

- Unit tests: `leave-balance.service.spec.ts`, `leave-accrual.service.spec.ts`, `leave-accrual-cron.service.spec.ts`, `leave.processor.spec.ts`.
- Integration tests: `leaves.integration.spec.ts` (full approval flow), `leave-balance.integration.spec.ts`, `leave-accruals.integration.spec.ts`, `holidays.integration.spec.ts`.

## Database Migrations

| Migration | Description |
|-----------|-------------|
| `20260429...` | Add Leave, LeaveBalance, Holiday, LeaveAccrualConfig models |
| `20260430...` | Leave status and type refinements |
| `20260501...` | Add accrual job tracking fields |
| `20260501...` | Add carryover cap to accrual config |
| `20260502...` | Remove manual accrual config overrides |