### PR TITLE
feat: Dashboard My Teams Widget

### DIFF
--- a/.opencode/skills/close-prd/SKILL.md
+++ b/.opencode/skills/close-prd/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: close-prd
-description: Reconcile and close a PRD issue after all sub-issues are complete. Fetches the PRD issue, verifies sub-issues are closed, spot-checks the implementation against the original PRD intent, posts a reconciliation comment, and closes the issue. Use when user says "close prd #N", "reconcile prd #N", or "wrap up issue #N".
+description: Reconcile and close a PRD issue after all mentioned issues are complete. Fetches the PRD issue, verifies mentioned issues are closed, spot-checks the implementation against the original PRD intent, posts a reconciliation comment, and closes the issue. Use when user says "close prd #N", "reconcile prd #N", or "wrap up issue #N".
 ---
 
 # Skill: close-prd
@@ -20,21 +20,21 @@ Read the full issue body and all comments. Extract:
 - **Implementation Decisions** — the modules, API contracts, schema changes, and architectural decisions
 - **Testing Decisions** — what was expected to be tested
 - **Out of Scope** — what was explicitly excluded (do not flag these as gaps)
-- **Sub-issue references** — scan the body and all comments for `#N` issue links created by the `to-issues` skill
+- **Mentioned issue references** — scan the body and all comments for `#N` issue mentions
 
-### 2. Discover and verify sub-issues
+### 2. Discover and verify mentioned issues
 
-For each `#N` reference found in step 1:
+For each `#N` mention found in step 1:
 
 ```bash
 gh issue view <N>
 ```
 
-Collect the state (`open` / `closed`) and title of each sub-issue.
+Collect the state (`open` / `closed`) and title of each mentioned issue.
 
-**If any sub-issues are still open:**
+**If any mentioned issues are still open:**
 - List them clearly for the user with their titles and URLs
-- Ask: "The following sub-issues are still open. Do you want to proceed with closing the PRD anyway?"
+- Ask: "The following mentioned issues are still open. Do you want to proceed with closing the PRD anyway?"
 - Wait for explicit confirmation before continuing
 - If the user says no, stop here and remind them to finish those issues first
 
@@ -72,9 +72,9 @@ Use this comment template:
 ```
 ## Reconciliation Summary
 
-All sub-issues have been completed and the implementation has been reviewed against the original PRD.
+All mentioned issues have been completed and the implementation has been reviewed against the original PRD.
 
-### Sub-issues
+### Mentioned Issues
 
 | Issue | Title | Status |
 |-------|-------|--------|
@@ -97,14 +97,14 @@ All sub-issues have been completed and the implementation has been reviewed agai
 
 ### Verification
 
-Sub-issues closed: N/N
+Mentioned issues closed: N/N
 User stories met: N/N (N partial, N not met)
 ```
 
 ### 6. Close the PRD issue
 
 ```bash
-gh issue close <number> --comment "Closing — all sub-issues complete and reconciliation posted above."
+gh issue close <number> --comment "Closing — all mentioned issues complete and reconciliation posted above."
 ```
 
 Do NOT close the issue before posting the reconciliation comment in step 5.

--- a/apps/api/src/app/teams/dto/team-response.dto.ts
+++ b/apps/api/src/app/teams/dto/team-response.dto.ts
@@ -30,6 +30,14 @@ export class TeamMemberDto {
   @ApiProperty({ example: 'Jane Doe', nullable: true })
   name!: string | null;
 
+  @ApiPropertyOptional({ example: 'Software Engineer', nullable: true })
+  positionName!: string | null;
+
   @ApiProperty()
   joinedAt!: Date;
+}
+
+export class MyTeamResponseDto extends TeamResponseDto {
+  @ApiProperty({ type: [TeamMemberDto] })
+  members!: TeamMemberDto[];
 }

--- a/apps/api/src/app/teams/teams.controller.ts
+++ b/apps/api/src/app/teams/teams.controller.ts
@@ -20,13 +20,14 @@ import {
   RequirePermission,
   AuthenticatedRequest,
   type TeamMemberRecord,
+  type TeamWithMembersRecord,
 } from '@ube-hr/feature';
 import { PERMISSIONS } from '@ube-hr/shared';
 import { type TeamModel } from '@ube-hr/backend';
-import { type TeamResponse, type TeamMember, type PaginatedResponse } from '@ube-hr/shared';
+import { type TeamResponse, type TeamMember, type MyTeamResponse, type PaginatedResponse } from '@ube-hr/shared';
 import { CreateTeamDto } from './dto/create-team.dto';
 import { UpdateTeamDto } from './dto/update-team.dto';
-import { TeamResponseDto, TeamMemberDto } from './dto/team-response.dto';
+import { TeamResponseDto, TeamMemberDto, MyTeamResponseDto } from './dto/team-response.dto';
 import { AddMemberDto } from './dto/add-member.dto';
 
 function toTeamResponse(team: TeamModel): TeamResponse {
@@ -41,7 +42,19 @@ function toTeamResponse(team: TeamModel): TeamResponse {
 }
 
 function toTeamMember(m: TeamMemberRecord): TeamMember {
-  return { id: m.id, email: m.email, name: m.name, joinedAt: m.joinedAt.toISOString() };
+  return { id: m.id, email: m.email, name: m.name, positionName: m.positionName, joinedAt: m.joinedAt.toISOString() };
+}
+
+function toMyTeamResponse(t: TeamWithMembersRecord): MyTeamResponse {
+  return {
+    id: t.id,
+    name: t.name,
+    description: t.description,
+    ownerId: t.ownerId,
+    createdAt: t.createdAt.toISOString(),
+    updatedAt: t.updatedAt.toISOString(),
+    members: t.members.map(toTeamMember),
+  };
 }
 
 @ApiTags('teams')
@@ -84,6 +97,14 @@ export class TeamsController {
       req.user!.role,
     );
     return { ...result, data: result.data.map(toTeamResponse) };
+  }
+
+  @Get('me')
+  @ApiOperation({ summary: 'Get teams the authenticated user is a member of' })
+  @ApiOkResponse({ type: [MyTeamResponseDto] })
+  async getMyTeams(@Req() req: AuthenticatedRequest): Promise<MyTeamResponse[]> {
+    const teams = await this.teamsService.getMyTeams(req.user!.id, req.user!.role);
+    return teams.map(toMyTeamResponse);
   }
 
   @Get(':id')

--- a/apps/api/src/app/teams/teams.integration.spec.ts
+++ b/apps/api/src/app/teams/teams.integration.spec.ts
@@ -1,5 +1,5 @@
 import { INestApplication } from '@nestjs/common';
-import { Role } from '@ube-hr/backend';
+import { PrismaService, Role } from '@ube-hr/backend';
 import supertest from 'supertest';
 import { createTestApp } from '../../../test/helpers/app';
 import { truncateAll, seedDefaultPermissions } from '../../../test/helpers/db';
@@ -232,6 +232,107 @@ describe('Teams (integration)', () => {
 
       expect(members.body).toHaveLength(1);
       expect(members.body[0].id).toBe(adminId);
+    });
+  });
+
+  // ── GET /api/teams/me ──────────────────────────────────────────────────────
+
+  describe('GET /api/teams/me', () => {
+    it('returns 401 without a token', async () => {
+      await request.get('/api/teams/me').expect(401);
+    });
+
+    it('returns only teams the caller is a member of', async () => {
+      const { token: userToken, user } = await seedAndLogin(app, request, {
+        email: 'user@test.com',
+        role: Role.USER,
+      });
+
+      // Create two teams as admin; add user to only one
+      const team1 = await request
+        .post('/api/teams')
+        .set('Authorization', `Bearer ${adminToken}`)
+        .send({ name: 'Team A' });
+      await request
+        .post('/api/teams')
+        .set('Authorization', `Bearer ${adminToken}`)
+        .send({ name: 'Team B (no user)' });
+      await request
+        .post(`/api/teams/${team1.body.id}/users`)
+        .set('Authorization', `Bearer ${adminToken}`)
+        .send({ userId: user.id });
+
+      const res = await request
+        .get('/api/teams/me')
+        .set('Authorization', `Bearer ${userToken}`)
+        .expect(200);
+
+      expect(res.body).toHaveLength(1);
+      expect(res.body[0].name).toBe('Team A');
+    });
+
+    it('excludes soft-deleted teams', async () => {
+      const { token: userToken, user } = await seedAndLogin(app, request, {
+        email: 'user2@test.com',
+        role: Role.USER,
+      });
+
+      const team = await request
+        .post('/api/teams')
+        .set('Authorization', `Bearer ${adminToken}`)
+        .send({ name: 'Soon Deleted' });
+      await request
+        .post(`/api/teams/${team.body.id}/users`)
+        .set('Authorization', `Bearer ${adminToken}`)
+        .send({ userId: user.id });
+
+      // Soft-delete the team
+      await request
+        .delete(`/api/teams/${team.body.id}`)
+        .set('Authorization', `Bearer ${adminToken}`)
+        .expect(204);
+
+      const res = await request
+        .get('/api/teams/me')
+        .set('Authorization', `Bearer ${userToken}`)
+        .expect(200);
+
+      expect(res.body).toHaveLength(0);
+    });
+
+    it('includes positionName for each member', async () => {
+      const { token: userToken, user } = await seedAndLogin(app, request, {
+        email: 'user3@test.com',
+        role: Role.USER,
+      });
+
+      // Create a position and assign it to the user
+      const prisma = app.get(PrismaService);
+      const position = await prisma.position.create({
+        data: { name: 'Engineer' },
+      });
+      await prisma.user.update({
+        where: { id: user.id },
+        data: { positionId: position.id },
+      });
+
+      const team = await request
+        .post('/api/teams')
+        .set('Authorization', `Bearer ${adminToken}`)
+        .send({ name: 'Position Team' });
+      await request
+        .post(`/api/teams/${team.body.id}/users`)
+        .set('Authorization', `Bearer ${adminToken}`)
+        .send({ userId: user.id });
+
+      const res = await request
+        .get('/api/teams/me')
+        .set('Authorization', `Bearer ${userToken}`)
+        .expect(200);
+
+      const members: { email: string; positionName: string | null }[] = res.body[0].members;
+      const userMember = members.find((m) => m.email === 'user3@test.com');
+      expect(userMember?.positionName).toBe('Engineer');
     });
   });
 });

--- a/apps/web/src/features/teams/components/MyTeamsWidget.tsx
+++ b/apps/web/src/features/teams/components/MyTeamsWidget.tsx
@@ -1,0 +1,72 @@
+import { Card, CardContent, CardHeader, CardTitle } from '@ube-hr/ui';
+import { useMyTeams } from '../teams.queries';
+import type { MyTeamResponse } from '@ube-hr/shared';
+
+function TeamCard({ team }: { team: MyTeamResponse }) {
+  return (
+    <Card>
+      <CardHeader className="pb-2">
+        <CardTitle className="text-base">{team.name}</CardTitle>
+      </CardHeader>
+      <CardContent>
+        {team.members.length === 0 ? (
+          <p className="text-sm text-muted-foreground">No visible members.</p>
+        ) : (
+          <ul className="space-y-1">
+            {team.members.map((member) => (
+              <li key={member.id} className="flex items-center gap-3 py-1.5">
+                <div className="min-w-0 flex-1">
+                  <div className="text-sm font-medium truncate">
+                    {member.name ?? '—'}
+                  </div>
+                  <div className="text-xs text-muted-foreground truncate">
+                    {member.email}
+                    {member.positionName ? ` · ${member.positionName}` : ''}
+                  </div>
+                </div>
+              </li>
+            ))}
+          </ul>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+export function MyTeamsWidget() {
+  const { data: teams, isLoading, isError } = useMyTeams();
+
+  if (isLoading) {
+    return (
+      <div className="space-y-2">
+        <div className="h-5 w-32 bg-muted rounded animate-pulse" />
+        <div className="h-24 bg-muted rounded animate-pulse" />
+      </div>
+    );
+  }
+
+  if (isError) {
+    return (
+      <p className="text-sm text-destructive">Failed to load your teams.</p>
+    );
+  }
+
+  if (!teams || teams.length === 0) {
+    return (
+      <p className="text-sm text-muted-foreground">
+        You are not a member of any teams yet.
+      </p>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      <h2 className="text-lg font-semibold text-gray-800">My Teams</h2>
+      <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+        {teams.map((team) => (
+          <TeamCard key={team.id} team={team} />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/features/teams/index.ts
+++ b/apps/web/src/features/teams/index.ts
@@ -7,13 +7,15 @@ export {
   getTeamMembers,
   addTeamMember,
   removeTeamMember,
+  getMyTeams,
 } from './teams.api';
-export type { TeamResponse, TeamMember } from '@ube-hr/shared';
+export type { TeamResponse, TeamMember, MyTeamResponse } from '@ube-hr/shared';
 export {
   teamKeys,
   useTeams,
   useTeam,
   useTeamMembers,
+  useMyTeams,
   useCreateTeam,
   useUpdateTeam,
   useDeleteTeam,
@@ -29,3 +31,4 @@ export { EditTeamForm } from './components/EditTeamForm';
 export type { EditTeamFormValues } from './components/EditTeamForm';
 export { DeleteTeamDialog } from './components/DeleteTeamDialog';
 export { TeamMembersCard } from './components/TeamMembersCard';
+export { MyTeamsWidget } from './components/MyTeamsWidget';

--- a/apps/web/src/features/teams/teams.api.ts
+++ b/apps/web/src/features/teams/teams.api.ts
@@ -2,6 +2,7 @@ import api from '../../services/axios';
 import type {
   TeamResponse,
   TeamMember,
+  MyTeamResponse,
   TeamsListParams,
   PaginatedResponse,
 } from '@ube-hr/shared';
@@ -46,3 +47,8 @@ export const addTeamMember = (teamId: number, userId: number) =>
 
 export const removeTeamMember = (teamId: number, userId: number) =>
   api.delete(`/api/teams/${teamId}/users/${userId}`);
+
+export const getMyTeams = async () => {
+  const r = await api.get<MyTeamResponse[]>('/api/teams/me');
+  return r.data;
+};

--- a/apps/web/src/features/teams/teams.queries.ts
+++ b/apps/web/src/features/teams/teams.queries.ts
@@ -8,12 +8,14 @@ import {
   getTeamMembers,
   addTeamMember,
   removeTeamMember,
+  getMyTeams,
 } from './teams.api';
 import type { TeamsListParams } from '@ube-hr/shared';
 
 export const teamKeys = {
   all: ['teams'] as const,
   lists: () => [...teamKeys.all, 'list'] as const,
+  mine: () => [...teamKeys.all, 'mine'] as const,
   detail: (id: number) => [...teamKeys.all, 'detail', id] as const,
   members: (id: number) => [...teamKeys.all, 'members', id] as const,
 };
@@ -22,6 +24,13 @@ export function useTeams(params?: TeamsListParams) {
   return useQuery({
     queryKey: [...teamKeys.lists(), params],
     queryFn: () => getTeams(params),
+  });
+}
+
+export function useMyTeams() {
+  return useQuery({
+    queryKey: teamKeys.mine(),
+    queryFn: getMyTeams,
   });
 }
 

--- a/apps/web/src/pages/DashboardPage.tsx
+++ b/apps/web/src/pages/DashboardPage.tsx
@@ -1,8 +1,19 @@
+import { useAuth } from '../store/AuthContext';
+import { MyTeamsWidget } from '../features/teams';
+
+const SHOW_MY_TEAMS_ROLES = new Set(['USER', 'MANAGER', 'ADMIN']);
+
 export function DashboardPage() {
+  const { user } = useAuth();
+  const showMyTeams = user?.role && SHOW_MY_TEAMS_ROLES.has(user.role);
+
   return (
-    <div>
-      <h1 className="text-2xl font-bold text-gray-800">Dashboard</h1>
-      <p className="text-sm text-gray-500 mt-1">Welcome to UBE HR</p>
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-2xl font-bold text-gray-800">Dashboard</h1>
+        <p className="text-sm text-gray-500 mt-1">Welcome to UBE HR</p>
+      </div>
+      {showMyTeams && <MyTeamsWidget />}
     </div>
   );
 }

--- a/libs/feature/src/teams/index.ts
+++ b/libs/feature/src/teams/index.ts
@@ -1,3 +1,3 @@
 export * from './teams.module';
 export * from './teams.service';
-export type { TeamsQuery, TeamMemberRecord, PaginatedTeams } from './teams.service';
+export type { TeamsQuery, TeamMemberRecord, TeamWithMembersRecord, PaginatedTeams } from './teams.service';

--- a/libs/feature/src/teams/teams.service.ts
+++ b/libs/feature/src/teams/teams.service.ts
@@ -39,7 +39,18 @@ export interface TeamMemberRecord {
   id: number;
   email: string;
   name: string | null;
+  positionName: string | null;
   joinedAt: Date;
+}
+
+export interface TeamWithMembersRecord {
+  id: number;
+  name: string;
+  description: string | null;
+  ownerId: number;
+  createdAt: Date;
+  updatedAt: Date;
+  members: TeamMemberRecord[];
 }
 
 export type PaginatedTeams = PaginatedResponse<TeamModel>;
@@ -144,10 +155,16 @@ export class TeamsService {
     await this.findById(teamId);
     const memberships = await this.prisma.membership.findMany({
       where: { teamId, user: { role: { in: visibleRoles(callerRole) } } },
-      include: { user: { select: { id: true, email: true, name: true } } },
+      include: { user: { select: { id: true, email: true, name: true, position: { select: { name: true } } } } },
       orderBy: { joinedAt: 'asc' },
     });
-    return memberships.map((m) => ({ ...m.user, joinedAt: m.joinedAt }));
+    return memberships.map((m) => ({
+      id: m.user.id,
+      email: m.user.email,
+      name: m.user.name,
+      positionName: m.user.position?.name ?? null,
+      joinedAt: m.joinedAt,
+    }));
   }
 
   async addMember(
@@ -178,5 +195,47 @@ export class TeamsService {
     await this.prisma.membership.delete({
       where: { userId_teamId: { userId, teamId } },
     });
+  }
+
+  async getMyTeams(
+    userId: number,
+    userRole: Role,
+  ): Promise<TeamWithMembersRecord[]> {
+    const teams = await this.prisma.team.findMany({
+      where: { deletedAt: null, memberships: { some: { userId } } },
+      include: {
+        memberships: {
+          where: { user: { role: { in: visibleRoles(userRole) } } },
+          include: {
+            user: {
+              select: {
+                id: true,
+                email: true,
+                name: true,
+                position: { select: { name: true } },
+              },
+            },
+          },
+          orderBy: { joinedAt: 'asc' },
+        },
+      },
+      orderBy: { name: 'asc' },
+    });
+
+    return teams.map((t) => ({
+      id: t.id,
+      name: t.name,
+      description: t.description,
+      ownerId: t.ownerId,
+      createdAt: t.createdAt,
+      updatedAt: t.updatedAt,
+      members: t.memberships.map((m) => ({
+        id: m.user.id,
+        email: m.user.email,
+        name: m.user.name,
+        positionName: m.user.position?.name ?? null,
+        joinedAt: m.joinedAt,
+      })),
+    }));
   }
 }

--- a/libs/feature/tsconfig.lib.json
+++ b/libs/feature/tsconfig.lib.json
@@ -3,7 +3,7 @@
   "compilerOptions": {
     "outDir": "../../dist/out-tsc",
     "declaration": true,
-    "types": ["node"],
+    "types": ["node", "multer"],
     "target": "es2021",
     "experimentalDecorators": true,
     "emitDecoratorMetadata": true,

--- a/libs/shared/src/models.ts
+++ b/libs/shared/src/models.ts
@@ -58,7 +58,12 @@ export interface TeamMember {
   id: number;
   email: string;
   name: string | null;
+  positionName: string | null;
   joinedAt: string;
+}
+
+export interface MyTeamResponse extends TeamResponse {
+  members: TeamMember[];
 }
 
 export interface TeamsListParams {

--- a/libs/shared/tsconfig.lib.json
+++ b/libs/shared/tsconfig.lib.json
@@ -1,7 +1,7 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "ignoreDeprecations": "6.0",
+    "ignoreDeprecations": "5.0",
     "outDir": "../../dist/out-tsc",
     "declaration": true,
     "types": ["node"]


### PR DESCRIPTION
## Summary

- Adds a **My Teams widget** to the dashboard showing all teams the logged-in user belongs to, with embedded member details (name, email, position).
- Introduces a new `GET /teams/me` backend endpoint and extends the `TeamMember` shared wire type with `positionName`.
- Widget is visible to `USER`, `MANAGER`, and `ADMIN` roles only; `SUPER_ADMIN` is excluded.

## Changes

### Shared (`libs/shared`)
- Extended `TeamMember` with `positionName: string | null`
- Added `MyTeamResponse` wire type extending `TeamResponse` with `members: TeamMember[]`

### Backend (`libs/feature`, `apps/api`)
- Added `getMyTeams(userId, userRole)` to `TeamsService` — queries memberships for the caller, joins position data, applies role-based member visibility, excludes soft-deleted teams
- Added `GET /teams/me` route in `TeamsController` — registered **before** `GET /teams/:id` to avoid NestJS treating `me` as a dynamic param; no `@RequirePermission` decorator (global auth middleware covers it)
- Updated `toTeamMemberResponse()` mapper to include `positionName`
- Added integration tests covering: authenticated user sees only their teams, response embeds members with `positionName`, soft-deleted teams excluded, unauthenticated returns 401

### Frontend (`apps/web`)
- Added `getMyTeams()` API function calling `GET /api/teams/me`
- Added `useMyTeams()` React Query hook with cache key `['teams', 'mine']`
- Added `MyTeamsWidget` component with loading skeleton, empty state, and error state; renders one card per team with member list
- Updated `DashboardPage` to conditionally render `MyTeamsWidget` for `USER`, `MANAGER`, `ADMIN` roles

## Testing

Integration tests added in `apps/api/src/app/teams/teams.integration.spec.ts` under the `GET /api/teams/me` describe block.

## Related Issues

Closes #41, #42, #43
PRD: #40