### PR TITLE
fix: correct leave approval chain routing for USER role

### DIFF
--- a/apps/api/src/app/leaves/leaves.controller.ts
+++ b/apps/api/src/app/leaves/leaves.controller.ts
@@ -249,7 +249,7 @@ export class LeavesController {
       id,
       req.user!.id,
       req.user!.role,
-      dto.override ?? false,
+      dto?.override ?? false,
     );
     return toLeaveResponse(leave);
   }

--- a/apps/api/src/app/users/users.controller.ts
+++ b/apps/api/src/app/users/users.controller.ts
@@ -41,6 +41,7 @@ import { StorageService } from '@ube-hr/backend';
 import { PERMISSIONS } from '@ube-hr/shared';
 import {
   type UserResponse,
+  type MyProfileResponse,
   type UserTeam,
   type PaginatedResponse,
   parseFormInt,
@@ -228,6 +229,21 @@ export class UsersController {
     // Permission check (role hierarchy) is handled inside usersService.update
     const user = await this.usersService.update(id, updateData, req.user!.role, req.user!.id);
     return toUserResponse(user, this.storageService);
+  }
+
+  @Get('me')
+  @ApiOperation({ summary: 'Get own profile with department and supervisor' })
+  @ApiOkResponse({ type: UserResponseDto })
+  async getMyProfile(
+    @Req() req: AuthenticatedRequest,
+  ): Promise<MyProfileResponse> {
+    const record = await this.usersService.findMyProfile(req.user!.id);
+    if (!record) throw new NotFoundException('User not found');
+    return {
+      ...toUserResponse(record, this.storageService),
+      supervisorId: record.supervisor?.id ?? null,
+      supervisorName: record.supervisor?.name ?? null,
+    };
   }
 
   @Get('assignable')

--- a/apps/web/src/features/users/index.ts
+++ b/apps/web/src/features/users/index.ts
@@ -1,6 +1,7 @@
 export {
   getUsers,
   getUser,
+  getMyProfile,
   getUserTeams,
   createUser,
   updateUser,
@@ -19,9 +20,10 @@ export { OwnedTeamsCard } from './components/OwnedTeamsCard';
 export { SecurityUpdateCard } from './components/SecurityUpdateCard';
 export type { CreateUserFormValues } from './components/CreateUserForm';
 export type { EditUserFormValues } from './components/EditUserForm';
-export type { UserResponse, UserTeam } from '@ube-hr/shared';
+export type { UserResponse, UserTeam, MyProfileResponse } from '@ube-hr/shared';
 export {
   userKeys,
+  useMyProfile,
   useUsers,
   useAssignableUsers,
   useUser,

--- a/apps/web/src/features/users/users.api.ts
+++ b/apps/web/src/features/users/users.api.ts
@@ -1,6 +1,7 @@
 import api from '../../services/axios';
 import type {
   UserResponse,
+  MyProfileResponse,
   UserTeam,
   UsersListParams,
   PaginatedResponse,
@@ -22,6 +23,11 @@ export const getAssignableUsers = async (params?: {
     '/api/users/assignable',
     { params },
   );
+  return r.data;
+};
+
+export const getMyProfile = async () => {
+  const r = await api.get<MyProfileResponse>('/api/users/me');
   return r.data;
 };
 

--- a/apps/web/src/features/users/users.queries.ts
+++ b/apps/web/src/features/users/users.queries.ts
@@ -7,6 +7,7 @@ import {
 import {
   getUsers,
   getUser,
+  getMyProfile,
   getUserTeams,
   createUser,
   updateUser,
@@ -22,6 +23,13 @@ export const userKeys = {
   detail: (id: number) => [...userKeys.all, 'detail', id] as const,
   teams: (id: number) => [...userKeys.all, 'teams', id] as const,
 };
+
+export function useMyProfile() {
+  return useQuery({
+    queryKey: ['users', 'me'] as const,
+    queryFn: getMyProfile,
+  });
+}
 
 export function useUsers(params?: UsersListParams) {
   return useQuery({

--- a/apps/web/src/pages/DashboardPage.tsx
+++ b/apps/web/src/pages/DashboardPage.tsx
@@ -1,11 +1,16 @@
 import { useAuth } from '../store/AuthContext';
 import { MyTeamsWidget } from '../features/teams';
+import { useMyProfile } from '../features/users';
 
 const SHOW_MY_TEAMS_ROLES = new Set(['USER', 'MANAGER', 'ADMIN']);
 
 export function DashboardPage() {
   const { user } = useAuth();
   const showMyTeams = user?.role && SHOW_MY_TEAMS_ROLES.has(user.role);
+  const { data: profile } = useMyProfile();
+
+  const hasDepartment = !!profile?.departmentName;
+  const hasSupervisor = !!profile?.supervisorName;
 
   return (
     <div className="space-y-6">
@@ -13,6 +18,24 @@ export function DashboardPage() {
         <h1 className="text-2xl font-bold text-gray-800">Dashboard</h1>
         <p className="text-sm text-gray-500 mt-1">Welcome to UBE HR</p>
       </div>
+
+      {(hasDepartment || hasSupervisor) && (
+        <div className="bg-white border border-gray-200 rounded-lg p-4 flex gap-6">
+          {hasDepartment && (
+            <div>
+              <p className="text-xs text-gray-500 uppercase tracking-wide">Department</p>
+              <p className="text-sm font-medium text-gray-800 mt-0.5">{profile.departmentName}</p>
+            </div>
+          )}
+          {hasSupervisor && (
+            <div>
+              <p className="text-xs text-gray-500 uppercase tracking-wide">Direct Supervisor</p>
+              <p className="text-sm font-medium text-gray-800 mt-0.5">{profile.supervisorName}</p>
+            </div>
+          )}
+        </div>
+      )}
+
       {showMyTeams && <MyTeamsWidget />}
     </div>
   );

--- a/libs/feature/src/leaves/leaves.service.spec.ts
+++ b/libs/feature/src/leaves/leaves.service.spec.ts
@@ -1,0 +1,150 @@
+import { Test } from '@nestjs/testing';
+import { PrismaService, Role, LeaveStatus, ApprovalStage } from '@ube-hr/backend';
+import { LeavesService } from './leaves.service';
+import { HolidaysService } from '../holidays/holidays.service';
+import { LeaveBalanceService } from '../leave-balance/leave-balance.service';
+import { QueueService } from '../queue/queue.service';
+
+const createPrismaMock = () => ({
+  membership: { findMany: jest.fn() },
+  user: { findUnique: jest.fn(), findMany: jest.fn() },
+  leaveRequest: { create: jest.fn() },
+  leaveBalance: { findUnique: jest.fn() },
+  leaveApprovalStep: { findMany: jest.fn() },
+  $transaction: jest.fn(),
+});
+
+describe('LeavesService — buildApprovalChain (USER role)', () => {
+  let service: LeavesService;
+  let prisma: ReturnType<typeof createPrismaMock>;
+
+  const holidaysService = { countWorkingDays: jest.fn() };
+  const leaveBalanceService = { addPending: jest.fn() };
+  const queue = { dispatch: jest.fn() };
+
+  beforeEach(async () => {
+    prisma = createPrismaMock();
+    const module = await Test.createTestingModule({
+      providers: [
+        LeavesService,
+        { provide: PrismaService, useValue: prisma },
+        { provide: HolidaysService, useValue: holidaysService },
+        { provide: LeaveBalanceService, useValue: leaveBalanceService },
+        { provide: QueueService, useValue: queue },
+      ],
+    }).compile();
+    service = module.get(LeavesService);
+  });
+
+  afterEach(() => jest.clearAllMocks());
+
+  const chain = (userId: number) =>
+    (service as any).buildApprovalChain(userId, Role.USER);
+
+  it('routes to non-owner MANAGER member in team', async () => {
+    prisma.membership.findMany
+      .mockResolvedValueOnce([{ teamId: 1 }])
+      .mockResolvedValueOnce([{ userId: 2 }]);
+
+    const result = await chain(99);
+
+    expect(result).toEqual({
+      status: LeaveStatus.PENDING_MANAGER,
+      approverIds: [2],
+      stage: ApprovalStage.MANAGER,
+    });
+  });
+
+  it('deduplicates MANAGER members across multiple teams', async () => {
+    prisma.membership.findMany
+      .mockResolvedValueOnce([{ teamId: 1 }, { teamId: 2 }])
+      .mockResolvedValueOnce([{ userId: 2 }, { userId: 2 }, { userId: 3 }]);
+
+    const result = await chain(99);
+
+    expect(result).toEqual({
+      status: LeaveStatus.PENDING_MANAGER,
+      approverIds: [2, 3],
+      stage: ApprovalStage.MANAGER,
+    });
+  });
+
+  it('falls back to department head when team has no MANAGER members', async () => {
+    prisma.membership.findMany
+      .mockResolvedValueOnce([{ teamId: 1 }])
+      .mockResolvedValueOnce([]);
+    prisma.user.findUnique.mockResolvedValue({
+      department: { head: { id: 5, deletedAt: null } },
+    });
+
+    const result = await chain(99);
+
+    expect(result).toEqual({
+      status: LeaveStatus.PENDING_MANAGER,
+      approverIds: [5],
+      stage: ApprovalStage.MANAGER,
+    });
+  });
+
+  it('routes to department head when user has no team', async () => {
+    prisma.membership.findMany.mockResolvedValueOnce([]);
+    prisma.user.findUnique.mockResolvedValue({
+      department: { head: { id: 5, deletedAt: null } },
+    });
+
+    const result = await chain(99);
+
+    expect(result).toEqual({
+      status: LeaveStatus.PENDING_MANAGER,
+      approverIds: [5],
+      stage: ApprovalStage.MANAGER,
+    });
+  });
+
+  it('skips department head when head is the filer; falls back to admins', async () => {
+    const userId = 99;
+    prisma.membership.findMany.mockResolvedValueOnce([]);
+    prisma.user.findUnique.mockResolvedValue({
+      department: { head: { id: userId, deletedAt: null } },
+    });
+    prisma.user.findMany.mockResolvedValue([{ id: 10 }]);
+
+    const result = await chain(userId);
+
+    expect(result).toEqual({
+      status: LeaveStatus.PENDING_ADMIN,
+      approverIds: [10],
+      stage: ApprovalStage.ADMIN,
+    });
+  });
+
+  it('skips soft-deleted department head; falls back to admins', async () => {
+    prisma.membership.findMany.mockResolvedValueOnce([]);
+    prisma.user.findUnique.mockResolvedValue({
+      department: { head: { id: 5, deletedAt: new Date() } },
+    });
+    prisma.user.findMany.mockResolvedValue([{ id: 10 }]);
+
+    const result = await chain(99);
+
+    expect(result).toEqual({
+      status: LeaveStatus.PENDING_ADMIN,
+      approverIds: [10],
+      stage: ApprovalStage.ADMIN,
+    });
+  });
+
+  it('routes directly to admins when user has no team and no department', async () => {
+    prisma.membership.findMany.mockResolvedValueOnce([]);
+    prisma.user.findUnique.mockResolvedValue({ department: null });
+    prisma.user.findMany.mockResolvedValue([{ id: 10 }, { id: 11 }]);
+
+    const result = await chain(99);
+
+    expect(result).toEqual({
+      status: LeaveStatus.PENDING_ADMIN,
+      approverIds: [10, 11],
+      stage: ApprovalStage.ADMIN,
+    });
+  });
+});

--- a/libs/feature/src/leaves/leaves.service.ts
+++ b/libs/feature/src/leaves/leaves.service.ts
@@ -674,11 +674,19 @@ export class LeavesService {
     stage: ApprovalStage;
   }> {
     if (userRole === Role.USER) {
-      const managerIds = await this.getTeamOwnerManagers(userId);
+      const managerIds = await this.getTeamMemberManagers(userId);
       if (managerIds.length > 0) {
         return {
           status: LeaveStatus.PENDING_MANAGER,
           approverIds: managerIds,
+          stage: ApprovalStage.MANAGER,
+        };
+      }
+      const deptHeadId = await this.getDepartmentHead(userId);
+      if (deptHeadId !== null) {
+        return {
+          status: LeaveStatus.PENDING_MANAGER,
+          approverIds: [deptHeadId],
           stage: ApprovalStage.MANAGER,
         };
       }
@@ -716,24 +724,39 @@ export class LeavesService {
     };
   }
 
-  private async getTeamOwnerManagers(userId: number): Promise<number[]> {
+  private async getTeamMemberManagers(userId: number): Promise<number[]> {
     const memberships = await this.prisma.membership.findMany({
       where: { userId },
+      select: { teamId: true },
+    });
+    const teamIds = memberships.map((m) => m.teamId);
+    if (teamIds.length === 0) return [];
+
+    const managers = await this.prisma.membership.findMany({
+      where: {
+        teamId: { in: teamIds },
+        userId: { not: userId },
+        user: { role: Role.MANAGER, deletedAt: null },
+      },
+      select: { userId: true },
+    });
+    return [...new Set(managers.map((m) => m.userId))];
+  }
+
+  private async getDepartmentHead(userId: number): Promise<number | null> {
+    const user = await this.prisma.user.findUnique({
+      where: { id: userId },
       select: {
-        team: {
+        department: {
           select: {
-            owner: { select: { id: true, role: true, deletedAt: true } },
+            head: { select: { id: true, deletedAt: true } },
           },
         },
       },
     });
-    const ids = new Set<number>();
-    for (const { team } of memberships) {
-      if (team.owner.role === Role.MANAGER && !team.owner.deletedAt) {
-        ids.add(team.owner.id);
-      }
-    }
-    return [...ids];
+    const head = user?.department?.head;
+    if (!head || head.deletedAt !== null || head.id === userId) return null;
+    return head.id;
   }
 
   private async getFellowManagers(userId: number): Promise<number[]> {

--- a/libs/feature/src/users/users.service.ts
+++ b/libs/feature/src/users/users.service.ts
@@ -328,6 +328,50 @@ export class UsersService {
     });
   }
 
+  async findMyProfile(userId: number): Promise<(UserRecord & { supervisor: { id: number; name: string | null } | null }) | null> {
+    const user = await this.prisma.user.findUnique({
+      where: { id: userId, deletedAt: null },
+      select: {
+        id: true,
+        email: true,
+        phone: true,
+        name: true,
+        role: true,
+        status: true,
+        profilePicture: true,
+        positionId: true,
+        position: {
+          select: {
+            id: true,
+            name: true,
+            reportsTo: {
+              select: {
+                users: {
+                  where: { deletedAt: null },
+                  select: { id: true, name: true },
+                  take: 1,
+                  orderBy: { id: 'asc' as const },
+                },
+              },
+            },
+          },
+        },
+        departmentId: true,
+        department: { select: { id: true, name: true } },
+        createdAt: true,
+      },
+    });
+
+    if (!user) return null;
+
+    const supervisor = user.position?.reportsTo?.users[0] ?? null;
+    return {
+      ...user,
+      position: user.position ? { id: user.position.id, name: user.position.name } : null,
+      supervisor,
+    };
+  }
+
   async findTeams(
     userId: number,
   ): Promise<

--- a/libs/shared/src/models.ts
+++ b/libs/shared/src/models.ts
@@ -114,6 +114,11 @@ export interface PositionsListParams {
   pageSize?: number;
 }
 
+export interface MyProfileResponse extends UserResponse {
+  supervisorId: number | null;
+  supervisorName: string | null;
+}
+
 // --- Auth wire types ---
 
 export interface MeResponse {


### PR DESCRIPTION
## Summary

- **Fixes leave approval chain routing** for USER-role filers. Previously the system only checked if the team *owner* had the MANAGER role, skipping over manager *members* and the department head entirely.
- **Adds a `GET /api/users/me` endpoint** that returns the authenticated user's profile with resolved department and direct supervisor.
- **Adds dashboard widgets** for department and direct supervisor on the Dashboard page.

## Changes

### Backend — Leave Approval Chain (`libs/feature/src/leaves/`)

| Before | After |
|--------|-------|
| `getTeamOwnerManagers` — checked only the team owner's role | `getTeamMemberManagers` — queries all membership rows across all the user's teams and returns every non-deleted MANAGER-role member (excluding self) |
| No department head fallback | `getDepartmentHead` — new private method; returns the department head's ID unless they are the filer or soft-deleted |
| USER with no team owner manager → directly to admins | USER with no team manager → dept head → admins (two-step fallback) |

New routing logic (USER branch):
```
In a team with MANAGER members? → PENDING_MANAGER (all such managers, deduplicated)
  else: Has a department head (not self, not deleted)? → PENDING_MANAGER (dept head)
    else: → PENDING_ADMIN (all admins)
```

### Backend — `GET /api/users/me` (`apps/api/`, `libs/feature/src/users/`, `libs/shared/`)

- New `findMyProfile(userId)` service method resolves supervisor by traversing `position → reportsTo → users[0]`.
- New `MyProfileResponse` wire type in `libs/shared/src/models.ts` extending `UserResponse` with `supervisorId` and `supervisorName`.
- New controller endpoint `GET /api/users/me` — no permission guard required (own profile).

### Frontend (`apps/web/`)

- `getMyProfile()` API call and `useMyProfile()` React Query hook (`queryKey: ['users', 'me']`).
- `DashboardPage` shows a compact info card with **Department** and **Direct Supervisor** when available.

### Tests (`libs/feature/src/leaves/leaves.service.spec.ts`)

7 unit test cases covering all PRD-specified scenarios:
- Team has a MANAGER member → routed to that manager
- Multiple teams with different managers → all included, deduplicated
- Team has no MANAGER members → falls back to department head
- User has no team but has a department head → routed to dept head
- User is their own department head → skips dept head, routes to admins
- Department head is soft-deleted → treated as absent, routes to admins
- No team, no department → routes to admins

## Closes

Closes #45