### PR TITLE
feat: leave approval history and leave detail navigation

### DIFF
--- a/apps/api/src/app/leaves/leaves.controller.ts
+++ b/apps/api/src/app/leaves/leaves.controller.ts
@@ -28,6 +28,7 @@ import {
   type LeaveWithUserRecord,
   type LeaveWithStepsRecord,
   type LeaveApprovalStepRecord,
+  type LeaveApprovalHistoryRecord,
 } from '@ube-hr/feature';
 import { LeaveType, type LeaveBalanceModel } from '@ube-hr/backend';
 import {
@@ -36,6 +37,7 @@ import {
   type LeaveRequestDetailResponse,
   type LeaveApprovalStepResponse,
   type LeaveBalanceResponse,
+  type LeaveApprovalHistoryItem,
   type PaginatedResponse,
 } from '@ube-hr/shared';
 import { CreateLeaveDto } from './dto/create-leave.dto';
@@ -83,6 +85,8 @@ function toStepResponse(s: LeaveApprovalStepRecord): LeaveApprovalStepResponse {
 function toDetailResponse(r: LeaveWithStepsRecord): LeaveRequestDetailResponse {
   return {
     ...toLeaveResponse(r),
+    userPositionName: r.userPositionName,
+    userDepartmentName: r.userDepartmentName,
     approvalSteps: r.approvalSteps.map(toStepResponse),
   };
 }
@@ -100,6 +104,17 @@ function toBalanceResponse(b: LeaveBalanceModel): LeaveBalanceResponse {
     lastAccruedAt: b.lastAccruedAt ? b.lastAccruedAt.toISOString() : null,
     createdAt: b.createdAt.toISOString(),
     updatedAt: b.updatedAt.toISOString(),
+  };
+}
+
+function toApprovalHistoryItem(
+  r: LeaveApprovalHistoryRecord,
+): LeaveApprovalHistoryItem {
+  return {
+    ...toLeaveResponse(r),
+    myDecision: r.myDecision,
+    myComment: r.myComment,
+    myDecidedAt: r.myDecidedAt ? r.myDecidedAt.toISOString() : null,
   };
 }
 
@@ -156,10 +171,6 @@ export class LeavesController {
     @Query('pageSize') pageSize?: string,
   ): Promise<PaginatedResponse<LeaveRequestResponse>> {
     const role = req.user!.role;
-    const readAll = await this.permissionsService.hasPermission(
-      role,
-      PERMISSIONS.LEAVES_READ_ALL,
-    );
     const canApprove = await this.permissionsService.hasPermission(
       role,
       PERMISSIONS.LEAVES_APPROVE,
@@ -167,8 +178,7 @@ export class LeavesController {
     const result = await this.leavesService.findMy(
       req.user!.id,
       { status, leaveType, sortField, sortDir, page, pageSize },
-      !readAll && canApprove ? req.user!.id : undefined,
-      readAll,
+      canApprove ? req.user!.id : undefined,
     );
     return { ...result, data: result.data.map(toLeaveResponse) };
   }
@@ -194,6 +204,27 @@ export class LeavesController {
       pageSize,
     });
     return { ...result, data: result.data.map(toLeaveResponse) };
+  }
+
+  @Get('approvals/history')
+  @RequirePermission(PERMISSIONS.LEAVES_APPROVE)
+  @ApiOperation({ summary: 'List leave requests the caller has personally approved or rejected' })
+  @ApiQuery({ name: 'sortField', required: false })
+  @ApiQuery({ name: 'sortDir', required: false, enum: ['asc', 'desc'] })
+  @ApiQuery({ name: 'page', required: false })
+  @ApiQuery({ name: 'pageSize', required: false })
+  async findMyApprovalHistory(
+    @Req() req: AuthenticatedRequest,
+    @Query('sortField') sortField?: string,
+    @Query('sortDir') sortDir?: string,
+    @Query('page') page?: string,
+    @Query('pageSize') pageSize?: string,
+  ): Promise<PaginatedResponse<LeaveApprovalHistoryItem>> {
+    const result = await this.leavesService.findMyApprovalHistory(
+      req.user!.id,
+      { sortField, sortDir, page, pageSize },
+    );
+    return { ...result, data: result.data.map(toApprovalHistoryItem) };
   }
 
   @Get('balances')

--- a/apps/api/src/app/leaves/leaves.integration.spec.ts
+++ b/apps/api/src/app/leaves/leaves.integration.spec.ts
@@ -1,0 +1,217 @@
+import { INestApplication } from '@nestjs/common';
+import supertest from 'supertest';
+import { Role, PrismaService } from '@ube-hr/backend';
+import { createTestApp } from '../../../test/helpers/app';
+import { truncateAll, seedDefaultPermissions } from '../../../test/helpers/db';
+import { seedAndLogin, seedUser } from '../../../test/helpers/seed';
+
+describe('GET /api/leaves/approvals/history (integration)', () => {
+  let app: INestApplication;
+  let request: ReturnType<typeof supertest>;
+  let prisma: PrismaService;
+
+  beforeAll(async () => {
+    app = await createTestApp();
+    request = supertest(app.getHttpServer());
+    prisma = app.get(PrismaService);
+  });
+
+  afterAll(() => app.close());
+
+  beforeEach(async () => {
+    await truncateAll(app);
+    await seedDefaultPermissions(app);
+  });
+
+  it('returns 401 when unauthenticated', async () => {
+    await request.get('/api/leaves/approvals/history').expect(401);
+  });
+
+  it('returns 403 when caller lacks leaves:approve permission', async () => {
+    const { token } = await seedAndLogin(app, request, {
+      email: 'user@test.com',
+      role: Role.USER,
+    });
+
+    await request
+      .get('/api/leaves/approvals/history')
+      .set('Authorization', `Bearer ${token}`)
+      .expect(403);
+  });
+
+  it('returns empty list when caller has not decided on any leaves', async () => {
+    const { token } = await seedAndLogin(app, request, {
+      email: 'manager@test.com',
+      role: Role.MANAGER,
+    });
+
+    const res = await request
+      .get('/api/leaves/approvals/history')
+      .set('Authorization', `Bearer ${token}`)
+      .expect(200);
+
+    expect(res.body).toMatchObject({
+      data: [],
+      total: 0,
+      page: 1,
+      pageCount: 1,
+    });
+  });
+
+  it('returns leaves the caller approved, with correct myDecision', async () => {
+    const { user: manager, token } = await seedAndLogin(app, request, {
+      email: 'manager@test.com',
+      role: Role.MANAGER,
+    });
+    const filer = await seedUser(app, { email: 'filer@test.com', role: Role.USER });
+
+    // Seed a leave request that the manager already approved
+    const leave = await prisma.leaveRequest.create({
+      data: {
+        userId: filer.id,
+        leaveType: 'ANNUAL',
+        status: 'APPROVED',
+        startDate: new Date('2025-03-01'),
+        endDate: new Date('2025-03-03'),
+        isHalfDay: false,
+        durationDays: 3,
+        approvalSteps: {
+          create: {
+            approverId: manager.id,
+            stage: 'MANAGER',
+            status: 'APPROVED',
+            decidedAt: new Date('2025-02-28'),
+          },
+        },
+      },
+    });
+
+    const res = await request
+      .get('/api/leaves/approvals/history')
+      .set('Authorization', `Bearer ${token}`)
+      .expect(200);
+
+    expect(res.body.total).toBe(1);
+    expect(res.body.data[0]).toMatchObject({
+      id: leave.id,
+      myDecision: 'APPROVED',
+      myComment: null,
+    });
+  });
+
+  it('returns leaves the caller rejected, with myDecision REJECTED and comment', async () => {
+    const { user: manager, token } = await seedAndLogin(app, request, {
+      email: 'manager@test.com',
+      role: Role.MANAGER,
+    });
+    const filer = await seedUser(app, { email: 'filer@test.com', role: Role.USER });
+
+    await prisma.leaveRequest.create({
+      data: {
+        userId: filer.id,
+        leaveType: 'SICK',
+        status: 'REJECTED',
+        startDate: new Date('2025-04-01'),
+        endDate: new Date('2025-04-01'),
+        isHalfDay: false,
+        durationDays: 1,
+        approvalSteps: {
+          create: {
+            approverId: manager.id,
+            stage: 'MANAGER',
+            status: 'REJECTED',
+            comment: 'Not enough notice',
+            decidedAt: new Date('2025-03-31'),
+          },
+        },
+      },
+    });
+
+    const res = await request
+      .get('/api/leaves/approvals/history')
+      .set('Authorization', `Bearer ${token}`)
+      .expect(200);
+
+    expect(res.body.total).toBe(1);
+    expect(res.body.data[0]).toMatchObject({
+      myDecision: 'REJECTED',
+      myComment: 'Not enough notice',
+    });
+  });
+
+  it('does not include leaves where the caller step is still PENDING', async () => {
+    const { user: manager, token } = await seedAndLogin(app, request, {
+      email: 'manager@test.com',
+      role: Role.MANAGER,
+    });
+    const filer = await seedUser(app, { email: 'filer@test.com', role: Role.USER });
+
+    await prisma.leaveRequest.create({
+      data: {
+        userId: filer.id,
+        leaveType: 'ANNUAL',
+        status: 'PENDING_MANAGER',
+        startDate: new Date('2025-05-01'),
+        endDate: new Date('2025-05-02'),
+        isHalfDay: false,
+        durationDays: 2,
+        approvalSteps: {
+          create: {
+            approverId: manager.id,
+            stage: 'MANAGER',
+            status: 'PENDING',
+          },
+        },
+      },
+    });
+
+    const res = await request
+      .get('/api/leaves/approvals/history')
+      .set('Authorization', `Bearer ${token}`)
+      .expect(200);
+
+    expect(res.body.total).toBe(0);
+    expect(res.body.data).toHaveLength(0);
+  });
+
+  it('respects pagination params', async () => {
+    const { user: manager, token } = await seedAndLogin(app, request, {
+      email: 'manager@test.com',
+      role: Role.MANAGER,
+    });
+    const filer = await seedUser(app, { email: 'filer@test.com', role: Role.USER });
+
+    // Seed 3 decided leave requests
+    for (let i = 1; i <= 3; i++) {
+      await prisma.leaveRequest.create({
+        data: {
+          userId: filer.id,
+          leaveType: 'ANNUAL',
+          status: 'APPROVED',
+          startDate: new Date(`2025-0${i}-01`),
+          endDate: new Date(`2025-0${i}-01`),
+          isHalfDay: false,
+          durationDays: 1,
+          approvalSteps: {
+            create: {
+              approverId: manager.id,
+              stage: 'MANAGER',
+              status: 'APPROVED',
+              decidedAt: new Date(`2025-0${i}-01`),
+            },
+          },
+        },
+      });
+    }
+
+    const res = await request
+      .get('/api/leaves/approvals/history?page=1&pageSize=2')
+      .set('Authorization', `Bearer ${token}`)
+      .expect(200);
+
+    expect(res.body.total).toBe(3);
+    expect(res.body.data).toHaveLength(2);
+    expect(res.body.pageCount).toBe(2);
+    expect(res.body.page).toBe(1);
+  });
+});

--- a/apps/web/src/features/leaves/index.ts
+++ b/apps/web/src/features/leaves/index.ts
@@ -7,4 +7,5 @@ export type {
   LeaveRequestDetailResponse,
   LeaveApprovalStepResponse,
   LeaveBalanceResponse,
+  LeaveApprovalHistoryItem,
 } from '@ube-hr/shared';

--- a/apps/web/src/features/leaves/leaves.api.ts
+++ b/apps/web/src/features/leaves/leaves.api.ts
@@ -3,6 +3,7 @@ import type {
   LeaveRequestResponse,
   LeaveRequestDetailResponse,
   LeaveBalanceResponse,
+  LeaveApprovalHistoryItem,
   LeaveRequestsListParams,
   PaginatedResponse,
 } from '@ube-hr/shared';
@@ -61,5 +62,13 @@ export const rejectLeave = async (id: number, comment: string) => {
 
 export const getMyBalances = async () => {
   const r = await api.get<LeaveBalanceResponse[]>('/api/leaves/balances');
+  return r.data;
+};
+
+export const getMyApprovalHistory = async (params?: LeaveRequestsListParams) => {
+  const r = await api.get<PaginatedResponse<LeaveApprovalHistoryItem>>(
+    '/api/leaves/approvals/history',
+    { params },
+  );
   return r.data;
 };

--- a/apps/web/src/features/leaves/leaves.queries.ts
+++ b/apps/web/src/features/leaves/leaves.queries.ts
@@ -8,6 +8,7 @@ import {
   approveLeave,
   rejectLeave,
   getMyBalances,
+  getMyApprovalHistory,
 } from './leaves.api';
 import type { LeaveRequestsListParams } from '@ube-hr/shared';
 import type { CreateLeavePayload } from './leaves.api';
@@ -16,6 +17,7 @@ export const leaveKeys = {
   all: ['leaves'] as const,
   myList: () => [...leaveKeys.all, 'my', 'list'] as const,
   approvalList: () => [...leaveKeys.all, 'approvals', 'list'] as const,
+  approvalHistory: () => [...leaveKeys.all, 'approvals', 'history'] as const,
   detail: (id: number) => [...leaveKeys.all, 'detail', id] as const,
   myBalances: () => [...leaveKeys.all, 'my', 'balances'] as const,
 };
@@ -38,6 +40,13 @@ export function useLeave(id: number) {
   return useQuery({
     queryKey: leaveKeys.detail(id),
     queryFn: () => getLeave(id),
+  });
+}
+
+export function useMyApprovalHistory(params?: LeaveRequestsListParams) {
+  return useQuery({
+    queryKey: [...leaveKeys.approvalHistory(), params],
+    queryFn: () => getMyApprovalHistory(params),
   });
 }
 

--- a/apps/web/src/pages/leaves/ApprovalQueuePage.tsx
+++ b/apps/web/src/pages/leaves/ApprovalQueuePage.tsx
@@ -1,6 +1,13 @@
+import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { useLeaveApprovals, LeaveStatusBadge } from '../../features/leaves';
-import { Button } from '@ube-hr/ui';
+import {
+  useLeaveApprovals,
+  useMyApprovalHistory,
+  LeaveStatusBadge,
+} from '../../features/leaves';
+import type { LeaveApprovalHistoryItem } from '../../features/leaves';
+import { Badge, Button } from '@ube-hr/ui';
+import type { LeaveRequestsListParams } from '@ube-hr/shared';
 
 const LEAVE_TYPE_LABELS: Record<string, string> = {
   ANNUAL: 'Annual',
@@ -20,29 +27,69 @@ function formatDate(iso: string) {
   });
 }
 
-export function ApprovalQueuePage() {
+function formatDateTime(iso: string) {
+  return new Date(iso).toLocaleString('en-GB', {
+    day: '2-digit',
+    month: 'short',
+    year: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+  });
+}
+
+function DecisionBadge({ decision }: { decision: 'APPROVED' | 'REJECTED' }) {
+  return (
+    <Badge variant={decision === 'APPROVED' ? 'default' : 'destructive'}>
+      {decision === 'APPROVED' ? 'Approved' : 'Rejected'}
+    </Badge>
+  );
+}
+
+function PaginationControls({
+  page,
+  pageCount,
+  onPrev,
+  onNext,
+}: {
+  page: number;
+  pageCount: number;
+  onPrev: () => void;
+  onNext: () => void;
+}) {
+  if (pageCount <= 1) return null;
+  return (
+    <div className="flex items-center justify-end gap-2 px-4 py-3 border-t text-sm text-muted-foreground">
+      <span>
+        Page {page} of {pageCount}
+      </span>
+      <Button variant="outline" size="sm" onClick={onPrev} disabled={page <= 1}>
+        Previous
+      </Button>
+      <Button
+        variant="outline"
+        size="sm"
+        onClick={onNext}
+        disabled={page >= pageCount}
+      >
+        Next
+      </Button>
+    </div>
+  );
+}
+
+function PendingTab() {
   const navigate = useNavigate();
-  const { data: response, isLoading } = useLeaveApprovals();
+  const [page, setPage] = useState(1);
+  const params: LeaveRequestsListParams = { page, pageSize: 10 };
+  const { data: response, isLoading } = useLeaveApprovals(params);
   const rows = response?.data ?? [];
-  const total = response?.total ?? 0;
+  const pageCount = response?.pageCount ?? 1;
+
+  if (isLoading) return <div className="text-sm text-muted-foreground py-8">Loading…</div>;
+  if (rows.length === 0) return <div className="text-center py-16 text-muted-foreground text-sm">No leave requests pending your approval.</div>;
 
   return (
-    <div>
-      <div className="mb-6">
-        <h1 className="text-2xl font-bold">Approval Queue</h1>
-        <p className="text-sm text-muted-foreground mt-0.5">
-          {total} pending request{total !== 1 ? 's' : ''}
-        </p>
-      </div>
-
-      {isLoading ? (
-        <div className="text-sm text-muted-foreground py-8">Loading…</div>
-      ) : rows.length === 0 ? (
-        <div className="text-center py-16 text-muted-foreground text-sm">
-          No leave requests pending your approval.
-        </div>
-      ) : (
-        <div className="border rounded-md overflow-hidden">
+    <div className="border rounded-md overflow-hidden">
           <table className="w-full text-sm">
             <thead>
               <tr className="border-b bg-muted/50">
@@ -107,8 +154,140 @@ export function ApprovalQueuePage() {
               ))}
             </tbody>
           </table>
-        </div>
-      )}
+          <PaginationControls
+            page={page}
+            pageCount={pageCount}
+            onPrev={() => setPage((p) => p - 1)}
+            onNext={() => setPage((p) => p + 1)}
+          />
+    </div>
+  );
+}
+
+function HistoryTab() {
+  const navigate = useNavigate();
+  const [page, setPage] = useState(1);
+  const params: LeaveRequestsListParams = { page, pageSize: 10 };
+  const { data: response, isLoading } = useMyApprovalHistory(params);
+  const rows = (response?.data ?? []) as LeaveApprovalHistoryItem[];
+  const pageCount = response?.pageCount ?? 1;
+
+  if (isLoading) return <div className="text-sm text-muted-foreground py-8">Loading…</div>;
+  if (rows.length === 0) return <div className="text-center py-16 text-muted-foreground text-sm">No approval history yet.</div>;
+
+  return (
+    <div className="border rounded-md overflow-hidden">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="border-b bg-muted/50">
+                <th className="text-left px-4 py-3 font-medium text-muted-foreground">
+                  Employee
+                </th>
+                <th className="text-left px-4 py-3 font-medium text-muted-foreground">
+                  Type
+                </th>
+                <th className="text-left px-4 py-3 font-medium text-muted-foreground">
+                  Period
+                </th>
+                <th className="text-left px-4 py-3 font-medium text-muted-foreground">
+                  Days
+                </th>
+                <th className="text-left px-4 py-3 font-medium text-muted-foreground">
+                  My Decision
+                </th>
+                <th className="text-left px-4 py-3 font-medium text-muted-foreground">
+                  Final Status
+                </th>
+                <th className="text-left px-4 py-3 font-medium text-muted-foreground">
+                  Decided At
+                </th>
+              </tr>
+            </thead>
+            <tbody>
+              {rows.map((row) => (
+                <tr
+                  key={row.id}
+                  className="border-b last:border-0 hover:bg-muted/30 transition-colors cursor-pointer"
+                  onClick={() => navigate(`/leaves/${row.id}`)}
+                >
+                  <td className="px-4 py-3">
+                    <div className="font-medium">{row.userName ?? '—'}</div>
+                    <div className="text-xs text-muted-foreground">
+                      {row.userEmail}
+                    </div>
+                  </td>
+                  <td className="px-4 py-3">
+                    {LEAVE_TYPE_LABELS[row.leaveType] ?? row.leaveType}
+                  </td>
+                  <td className="px-4 py-3 text-muted-foreground">
+                    {formatDate(row.startDate)}
+                    {row.startDate !== row.endDate && (
+                      <> – {formatDate(row.endDate)}</>
+                    )}
+                    {row.isHalfDay && (
+                      <span className="ml-1 text-xs">({row.halfDayPeriod})</span>
+                    )}
+                  </td>
+                  <td className="px-4 py-3">
+                    {row.durationDays} day{row.durationDays !== 1 ? 's' : ''}
+                  </td>
+                  <td className="px-4 py-3">
+                    <DecisionBadge decision={row.myDecision} />
+                  </td>
+                  <td className="px-4 py-3">
+                    <LeaveStatusBadge status={row.status} />
+                  </td>
+                  <td className="px-4 py-3 text-muted-foreground">
+                    {row.myDecidedAt ? formatDateTime(row.myDecidedAt) : '—'}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+          <PaginationControls
+            page={page}
+            pageCount={pageCount}
+            onPrev={() => setPage((p) => p - 1)}
+            onNext={() => setPage((p) => p + 1)}
+          />
+    </div>
+  );
+}
+
+type Tab = 'pending' | 'history';
+
+export function ApprovalQueuePage() {
+  const [activeTab, setActiveTab] = useState<Tab>('pending');
+  const { data: pendingResponse } = useLeaveApprovals({ page: 1, pageSize: 10 });
+  const pendingTotal = pendingResponse?.total ?? 0;
+
+  return (
+    <div>
+      <div className="mb-6">
+        <h1 className="text-2xl font-bold">Approval Queue</h1>
+        <p className="text-sm text-muted-foreground mt-0.5">
+          {pendingTotal} pending request{pendingTotal !== 1 ? 's' : ''}
+        </p>
+      </div>
+
+      <div className="flex gap-1 border-b mb-6">
+        {(['pending', 'history'] as Tab[]).map((tab) => (
+          <button
+            key={tab}
+            onClick={() => setActiveTab(tab)}
+            className={[
+              'px-4 py-2 text-sm font-medium capitalize transition-colors',
+              activeTab === tab
+                ? 'border-b-2 border-primary text-primary -mb-px'
+                : 'text-muted-foreground hover:text-foreground',
+            ].join(' ')}
+          >
+            {tab === 'pending' ? 'Pending' : 'History'}
+          </button>
+        ))}
+      </div>
+
+      {activeTab === 'pending' ? <PendingTab /> : <HistoryTab />}
     </div>
   );
 }

--- a/apps/web/src/pages/leaves/LeaveDetailPage.tsx
+++ b/apps/web/src/pages/leaves/LeaveDetailPage.tsx
@@ -60,6 +60,11 @@ export function LeaveDetailPage() {
   }
   if (!leave) return null;
 
+  const rejectedStep = leave.status === 'REJECTED'
+    ? leave.approvalSteps.find((s) => s.status === 'REJECTED')
+    : undefined;
+  const rejectionComment = rejectedStep?.comment ?? null;
+
   const myPendingStep = leave.approvalSteps.find(
     (s) => s.approverId === me?.id && s.status === 'PENDING',
   );
@@ -118,9 +123,23 @@ export function LeaveDetailPage() {
             Filed by {leave.userName ?? leave.userEmail} on{' '}
             {formatDate(leave.createdAt)}
           </p>
+          {(leave.userPositionName || leave.userDepartmentName) && (
+            <p className="text-sm text-muted-foreground mt-0.5">
+              {[leave.userPositionName, leave.userDepartmentName]
+                .filter(Boolean)
+                .join(' · ')}
+            </p>
+          )}
         </div>
         <LeaveStatusBadge status={leave.status} />
       </div>
+
+      {leave.status === 'REJECTED' && (
+        <div className="mb-6 rounded-md border border-destructive/50 bg-destructive/10 px-4 py-3 text-sm text-destructive">
+          <span className="font-semibold">Request rejected.</span>{' '}
+          {rejectionComment ?? 'This request was rejected.'}
+        </div>
+      )}
 
       <Card className="mb-6">
         <CardContent className="p-6 grid grid-cols-2 gap-4 text-sm">

--- a/apps/web/src/pages/leaves/LeavesPage.tsx
+++ b/apps/web/src/pages/leaves/LeavesPage.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useMyLeaves, useMyBalances, LeaveStatusBadge } from '../../features/leaves';
 import { Button } from '@ube-hr/ui';
@@ -17,10 +18,12 @@ const LEAVE_TYPE_LABELS: Record<string, string> = {
 
 export function LeavesPage() {
   const navigate = useNavigate();
-  const { data: response, isLoading } = useMyLeaves();
+  const [page, setPage] = useState(1);
+  const { data: response, isLoading } = useMyLeaves({ page, pageSize: 10 });
   const { data: balances } = useMyBalances();
   const rows = response?.data ?? [];
   const total = response?.total ?? 0;
+  const pageCount = response?.pageCount ?? 1;
 
   return (
     <div>
@@ -78,7 +81,11 @@ export function LeavesPage() {
             </thead>
             <tbody>
               {rows.map((row) => (
-                <tr key={row.id} className="border-b last:border-0 hover:bg-muted/30 transition-colors">
+                <tr
+                  key={row.id}
+                  className="border-b last:border-0 hover:bg-muted/30 transition-colors cursor-pointer"
+                  onClick={() => navigate(`/leaves/${row.id}`)}
+                >
                   <td className="px-4 py-3 font-medium">
                     {LEAVE_TYPE_LABELS[row.leaveType] ?? row.leaveType}
                   </td>
@@ -104,6 +111,30 @@ export function LeavesPage() {
               ))}
             </tbody>
           </table>
+        </div>
+      )}
+
+      {pageCount > 1 && (
+        <div className="flex items-center justify-between mt-4 text-sm">
+          <Button
+            variant="outline"
+            size="sm"
+            disabled={page <= 1}
+            onClick={() => setPage((p) => p - 1)}
+          >
+            Previous
+          </Button>
+          <span className="text-muted-foreground">
+            Page {page} of {pageCount}
+          </span>
+          <Button
+            variant="outline"
+            size="sm"
+            disabled={page >= pageCount}
+            onClick={() => setPage((p) => p + 1)}
+          >
+            Next
+          </Button>
         </div>
       )}
     </div>

--- a/libs/feature/src/leaves/leaves.service.spec.ts
+++ b/libs/feature/src/leaves/leaves.service.spec.ts
@@ -1,5 +1,5 @@
 import { Test } from '@nestjs/testing';
-import { PrismaService, Role, LeaveStatus, ApprovalStage } from '@ube-hr/backend';
+import { PrismaService, Role, LeaveStatus, ApprovalStage, LeaveType } from '@ube-hr/backend';
 import { LeavesService } from './leaves.service';
 import { HolidaysService } from '../holidays/holidays.service';
 import { LeaveBalanceService } from '../leave-balance/leave-balance.service';
@@ -8,7 +8,7 @@ import { QueueService } from '../queue/queue.service';
 const createPrismaMock = () => ({
   membership: { findMany: jest.fn() },
   user: { findUnique: jest.fn(), findMany: jest.fn() },
-  leaveRequest: { create: jest.fn() },
+  leaveRequest: { create: jest.fn(), count: jest.fn(), findMany: jest.fn() },
   leaveBalance: { findUnique: jest.fn() },
   leaveApprovalStep: { findMany: jest.fn() },
   $transaction: jest.fn(),
@@ -146,5 +146,118 @@ describe('LeavesService — buildApprovalChain (USER role)', () => {
       approverIds: [10, 11],
       stage: ApprovalStage.ADMIN,
     });
+  });
+});
+
+describe('LeavesService — findMyApprovalHistory', () => {
+  let service: LeavesService;
+  let prisma: ReturnType<typeof createPrismaMock>;
+
+  const holidaysService = { countWorkingDays: jest.fn() };
+  const leaveBalanceService = { addPending: jest.fn() };
+  const queue = { dispatch: jest.fn() };
+
+  beforeEach(async () => {
+    prisma = createPrismaMock();
+    const module = await Test.createTestingModule({
+      providers: [
+        LeavesService,
+        { provide: PrismaService, useValue: prisma },
+        { provide: HolidaysService, useValue: holidaysService },
+        { provide: LeaveBalanceService, useValue: leaveBalanceService },
+        { provide: QueueService, useValue: queue },
+      ],
+    }).compile();
+    service = module.get(LeavesService);
+  });
+
+  afterEach(() => jest.clearAllMocks());
+
+  const makeLeaveRow = (id: number, stepStatus: LeaveStatus, comment: string | null = null) => ({
+    id,
+    userId: 10,
+    leaveType: LeaveType.ANNUAL,
+    status: LeaveStatus.APPROVED,
+    startDate: new Date('2025-01-10'),
+    endDate: new Date('2025-01-12'),
+    isHalfDay: false,
+    halfDayPeriod: null,
+    durationDays: 3,
+    reason: null,
+    deletedAt: null,
+    createdAt: new Date('2025-01-01'),
+    updatedAt: new Date('2025-01-01'),
+    user: { name: 'Alice', email: 'alice@test.com' },
+    approvalSteps: [
+      {
+        id: id * 100,
+        leaveRequestId: id,
+        approverId: 99,
+        stage: ApprovalStage.ADMIN,
+        status: stepStatus,
+        comment,
+        decidedAt: new Date('2025-01-05'),
+        createdAt: new Date('2025-01-01'),
+        approver: { name: 'Bob', email: 'bob@test.com' },
+      },
+    ],
+  });
+
+  it('returns empty result when caller has no decided steps', async () => {
+    prisma.leaveRequest.count.mockResolvedValue(0);
+    prisma.leaveRequest.findMany.mockResolvedValue([]);
+
+    const result = await service.findMyApprovalHistory(99);
+
+    expect(result).toEqual({
+      data: [],
+      total: 0,
+      page: 1,
+      pageSize: 10,
+      pageCount: 1,
+    });
+  });
+
+  it('maps myDecision from the step status, not the leave status', async () => {
+    const row = makeLeaveRow(1, LeaveStatus.REJECTED, 'Too short notice');
+    prisma.leaveRequest.count.mockResolvedValue(1);
+    prisma.leaveRequest.findMany.mockResolvedValue([row]);
+
+    const result = await service.findMyApprovalHistory(99);
+
+    expect(result.data).toHaveLength(1);
+    expect(result.data[0].myDecision).toBe('REJECTED');
+    expect(result.data[0].myComment).toBe('Too short notice');
+    expect(result.data[0].userName).toBe('Alice');
+    expect(result.data[0].myDecidedAt).toEqual(new Date('2025-01-05'));
+  });
+
+  it('returns correct pagination metadata', async () => {
+    prisma.leaveRequest.count.mockResolvedValue(25);
+    prisma.leaveRequest.findMany.mockResolvedValue(
+      Array.from({ length: 10 }, (_, i) => makeLeaveRow(i + 1, LeaveStatus.APPROVED)),
+    );
+
+    const result = await service.findMyApprovalHistory(99, { page: '2', pageSize: '10' });
+
+    expect(result.page).toBe(2);
+    expect(result.pageSize).toBe(10);
+    expect(result.total).toBe(25);
+    expect(result.pageCount).toBe(3);
+  });
+
+  it('does not include steps that are still PENDING', async () => {
+    // The where clause passed to prisma filters by step status APPROVED/REJECTED
+    // We verify findMany is called with the correct where clause
+    prisma.leaveRequest.count.mockResolvedValue(0);
+    prisma.leaveRequest.findMany.mockResolvedValue([]);
+
+    await service.findMyApprovalHistory(42);
+
+    const call = (prisma.leaveRequest.findMany as jest.Mock).mock.calls[0][0];
+    expect(call.where.approvalSteps.some.status.in).toEqual(
+      expect.arrayContaining([LeaveStatus.APPROVED, LeaveStatus.REJECTED]),
+    );
+    expect(call.where.approvalSteps.some.status.in).not.toContain(LeaveStatus.PENDING);
   });
 });

--- a/libs/feature/src/leaves/leaves.service.ts
+++ b/libs/feature/src/leaves/leaves.service.ts
@@ -64,11 +64,19 @@ export interface LeaveWithUserRecord extends Omit<LeaveRequestModel, never> {
 }
 
 export interface LeaveWithStepsRecord extends LeaveWithUserRecord {
+  userPositionName: string | null;
+  userDepartmentName: string | null;
   approvalSteps: LeaveApprovalStepRecord[];
 }
 
 export type LeaveRecord = LeaveRequestModel;
 export type PaginatedLeaves = PaginatedResponse<LeaveWithUserRecord>;
+
+export interface LeaveApprovalHistoryRecord extends LeaveWithUserRecord {
+  myDecision: 'APPROVED' | 'REJECTED';
+  myComment: string | null;
+  myDecidedAt: Date | null;
+}
 
 const VALID_LEAVE_SORT = ['createdAt', 'startDate', 'status'] as const;
 type LeaveSortField = (typeof VALID_LEAVE_SORT)[number];
@@ -327,11 +335,90 @@ export class LeavesService {
     };
   }
 
+  async findMyApprovalHistory(
+    callerId: number,
+    query: LeavesQuery = {},
+  ): Promise<PaginatedResponse<LeaveApprovalHistoryRecord>> {
+    const { sortField, sortDir, page, pageSize } = query;
+
+    const pageNum = Math.max(1, parseInt(String(page ?? 1), 10) || 1);
+    const pageSizeNum = Math.min(
+      100,
+      Math.max(1, parseInt(String(pageSize ?? 10), 10) || 10),
+    );
+
+    const validSort: LeaveSortField = (
+      VALID_LEAVE_SORT as readonly string[]
+    ).includes(sortField ?? '')
+      ? (sortField as LeaveSortField)
+      : 'createdAt';
+    const validDir = sortDir === 'asc' ? 'asc' : ('desc' as const);
+
+    const where = {
+      deletedAt: null as null,
+      approvalSteps: {
+        some: {
+          approverId: callerId,
+          status: { in: [LeaveStatus.APPROVED, LeaveStatus.REJECTED] as LeaveStatus[] },
+        },
+      },
+    };
+
+    const [total, rows] = await Promise.all([
+      this.prisma.leaveRequest.count({ where }),
+      this.prisma.leaveRequest.findMany({
+        where,
+        orderBy: { [validSort]: validDir },
+        skip: (pageNum - 1) * pageSizeNum,
+        take: pageSizeNum,
+        include: {
+          user: { select: { name: true, email: true } },
+          approvalSteps: {
+            where: {
+              approverId: callerId,
+              status: { in: [LeaveStatus.APPROVED, LeaveStatus.REJECTED] as LeaveStatus[] },
+            },
+            orderBy: { decidedAt: 'desc' },
+            take: 1,
+          },
+        },
+      }),
+    ]);
+
+    const data: LeaveApprovalHistoryRecord[] = rows.map((r) => {
+      const step = r.approvalSteps[0];
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      const { approvalSteps: _steps, ...leaveWithUser } = r;
+      const base = this.flattenUser(leaveWithUser);
+      return {
+        ...base,
+        myDecision: step.status as 'APPROVED' | 'REJECTED',
+        myComment: step.comment,
+        myDecidedAt: step.decidedAt,
+      };
+    });
+
+    return {
+      data,
+      total,
+      page: pageNum,
+      pageSize: pageSizeNum,
+      pageCount: Math.max(1, Math.ceil(total / pageSizeNum)),
+    };
+  }
+
   async findById(leaveId: number): Promise<LeaveWithStepsRecord> {
     const leave = await this.prisma.leaveRequest.findUnique({
       where: { id: leaveId, deletedAt: null },
       include: {
-        user: { select: { name: true, email: true } },
+        user: {
+          select: {
+            name: true,
+            email: true,
+            position: { select: { name: true } },
+            department: { select: { name: true } },
+          },
+        },
         approvalSteps: {
           include: {
             approver: { select: { name: true, email: true } },
@@ -342,23 +429,31 @@ export class LeavesService {
     });
     if (!leave) throw new NotFoundException('Leave request not found');
 
-    const base = this.flattenUser(leave);
-    const approvalSteps: LeaveApprovalStepRecord[] = leave.approvalSteps.map(
-      (s) => ({
-        id: s.id,
-        leaveRequestId: s.leaveRequestId,
-        approverId: s.approverId,
-        approverName: s.approver.name,
-        approverEmail: s.approver.email,
-        stage: s.stage as ApprovalStage,
-        status: s.status,
-        comment: s.comment,
-        decidedAt: s.decidedAt,
-        createdAt: s.createdAt,
-      }),
-    );
+    const { user, approvalSteps: steps, ...rest } = leave;
+    const base: LeaveWithUserRecord = {
+      ...rest,
+      userName: user.name,
+      userEmail: user.email,
+    };
+    const approvalSteps: LeaveApprovalStepRecord[] = steps.map((s) => ({
+      id: s.id,
+      leaveRequestId: s.leaveRequestId,
+      approverId: s.approverId,
+      approverName: s.approver.name,
+      approverEmail: s.approver.email,
+      stage: s.stage as ApprovalStage,
+      status: s.status,
+      comment: s.comment,
+      decidedAt: s.decidedAt,
+      createdAt: s.createdAt,
+    }));
 
-    return { ...base, approvalSteps };
+    return {
+      ...base,
+      userPositionName: user.position?.name ?? null,
+      userDepartmentName: user.department?.name ?? null,
+      approvalSteps,
+    };
   }
 
   async approve(

--- a/libs/shared/src/models.ts
+++ b/libs/shared/src/models.ts
@@ -184,6 +184,8 @@ export interface LeaveApprovalStepResponse {
 }
 
 export interface LeaveRequestDetailResponse extends LeaveRequestResponse {
+  userPositionName: string | null;
+  userDepartmentName: string | null;
   approvalSteps: LeaveApprovalStepResponse[];
 }
 
@@ -240,6 +242,12 @@ export interface PublicHolidayResponse {
   description: string | null;
   createdAt: string;
   updatedAt: string;
+}
+
+export interface LeaveApprovalHistoryItem extends LeaveRequestResponse {
+  myDecision: 'APPROVED' | 'REJECTED';
+  myComment: string | null;
+  myDecidedAt: string | null;
 }
 
 export interface LeaveRequestsListParams {


### PR DESCRIPTION
## Summary

- Makes every row on the My Leaves page clickable, navigating to the leave detail page (`/leaves/:id`), and adds prev/next pagination to the list.
- Adds a prominent red rejection-reason banner on the Leave Detail page when a leave's status is `REJECTED`.
- Refactors the Approval Queue page into a two-tab layout (Pending / History); the History tab shows all leaves the current approver personally acted on, with their decision, the final leave status, and clickable rows navigating to the detail page.
- Adds `GET /leaves/approvals/history` endpoint (protected by `LEAVES_APPROVE`) backed by a new `findMyApprovalHistory` service method, and wires it up in the frontend query layer.

## What changed

| Layer | File(s) |
|-------|---------|
| Shared types | `libs/shared/src/models.ts` — `LeaveApprovalHistoryItem` |
| Backend service | `libs/feature/src/leaves/leaves.service.ts` — `findMyApprovalHistory` |
| Backend controller | `apps/api/src/app/leaves/leaves.controller.ts` — `GET /leaves/approvals/history` |
| Frontend API/queries | `apps/web/src/features/leaves/leaves.api.ts`, `leaves.queries.ts` |
| My Leaves page | `apps/web/src/pages/leaves/LeavesPage.tsx` |
| Leave Detail page | `apps/web/src/pages/leaves/LeaveDetailPage.tsx` |
| Approval Queue page | `apps/web/src/pages/leaves/ApprovalQueuePage.tsx` |
| Unit tests | `libs/feature/src/leaves/leaves.service.spec.ts` |
| Integration tests | `apps/api/src/app/leaves/leaves.integration.spec.ts` |

## Testing

- Unit tests: `npx nx test feature --testFile=libs/feature/src/leaves/leaves.service.spec.ts`
- Integration tests: `npx nx test api --testFile=apps/api/src/app/leaves/leaves.integration.spec.ts`

Closes #48