### PR TITLE
feat: group sidebar nav and fix form-ready guard on detail pages

### DIFF
--- a/apps/web/src/layouts/AuthLayout.tsx
+++ b/apps/web/src/layouts/AuthLayout.tsx
@@ -9,46 +9,70 @@ interface NavItem {
   to: string;
   label: string;
   permission?: string;
+  end?: boolean;
 }
 
-const navItems: NavItem[] = [
-  { to: '/dashboard', label: 'Dashboard' },
-  { to: '/users', label: 'Users', permission: PERMISSIONS.USERS_READ },
-  { to: '/teams', label: 'Teams', permission: PERMISSIONS.TEAMS_READ },
+interface NavGroup {
+  label?: string;
+  items: NavItem[];
+}
+
+const navGroups: NavGroup[] = [
   {
-    to: '/departments',
-    label: 'Departments',
-    permission: PERMISSIONS.DEPARTMENTS_READ,
+    items: [{ to: '/dashboard', label: 'Dashboard' }],
   },
   {
-    to: '/positions',
-    label: 'Positions',
-    permission: PERMISSIONS.POSITIONS_READ,
+    label: 'Organization',
+    items: [
+      { to: '/users', label: 'Users', permission: PERMISSIONS.USERS_READ },
+      { to: '/teams', label: 'Teams', permission: PERMISSIONS.TEAMS_READ },
+      {
+        to: '/departments',
+        label: 'Departments',
+        permission: PERMISSIONS.DEPARTMENTS_READ,
+      },
+      {
+        to: '/positions',
+        label: 'Positions',
+        permission: PERMISSIONS.POSITIONS_READ,
+      },
+      {
+        to: '/org-chart',
+        label: 'Org Chart',
+        permission: PERMISSIONS.POSITIONS_READ,
+      },
+    ],
   },
   {
-    to: '/org-chart',
-    label: 'Org Chart',
-    permission: PERMISSIONS.POSITIONS_READ,
+    label: 'Leave',
+    items: [
+      {
+        to: '/leaves',
+        label: 'My Leaves',
+        permission: PERMISSIONS.LEAVES_READ,
+        end: true,
+      },
+      {
+        to: '/leaves/approvals',
+        label: 'Approval Queue',
+        permission: PERMISSIONS.LEAVES_APPROVE,
+      },
+    ],
   },
   {
-    to: '/leaves',
-    label: 'My Leaves',
-    permission: PERMISSIONS.LEAVES_READ,
-  },
-  {
-    to: '/leaves/approvals',
-    label: 'Approval Queue',
-    permission: PERMISSIONS.LEAVES_APPROVE,
-  },
-  {
-    to: '/admin/holidays',
-    label: 'Holidays',
-    permission: PERMISSIONS.HOLIDAYS_MANAGE,
-  },
-  {
-    to: '/admin/leave-balance',
-    label: 'Leave Balances',
-    permission: PERMISSIONS.LEAVES_BALANCE_MANAGE,
+    label: 'Admin',
+    items: [
+      {
+        to: '/admin/holidays',
+        label: 'Holidays',
+        permission: PERMISSIONS.HOLIDAYS_MANAGE,
+      },
+      {
+        to: '/admin/leave-balance',
+        label: 'Leave Balances',
+        permission: PERMISSIONS.LEAVES_BALANCE_MANAGE,
+      },
+    ],
   },
 ];
 
@@ -57,10 +81,15 @@ export function AuthLayout() {
   const navigate = useNavigate();
   const { data: me } = useMe();
 
-  const visibleNavItems = navItems.filter(
-    ({ permission }) =>
-      !permission || (me?.permissions?.includes(permission) ?? false),
-  );
+  const visibleGroups = navGroups
+    .map((group) => ({
+      ...group,
+      items: group.items.filter(
+        ({ permission }) =>
+          !permission || (me?.permissions?.includes(permission) ?? false),
+      ),
+    }))
+    .filter((group) => group.items.length > 0);
 
   async function handleLogout() {
     await api.post('/api/auth/logout');
@@ -86,21 +115,33 @@ export function AuthLayout() {
         </div>
 
         {/* Navigation */}
-        <nav className="flex-1 px-3 py-4 space-y-1">
-          {visibleNavItems.map(({ to, label }) => (
-            <NavLink
-              key={to}
-              to={to}
-              className={({ isActive }) =>
-                `flex items-center px-3 py-2 rounded-md text-sm font-medium transition-colors ${
-                  isActive
-                    ? 'bg-primary text-primary-foreground'
-                    : 'text-muted-foreground hover:bg-accent hover:text-accent-foreground'
-                }`
-              }
-            >
-              {label}
-            </NavLink>
+        <nav className="flex-1 px-3 py-4 space-y-4 overflow-y-auto">
+          {visibleGroups.map((group, i) => (
+            <div key={i}>
+              {group.label && (
+                <p className="px-3 mb-1 text-xs font-semibold uppercase tracking-wider text-muted-foreground/60">
+                  {group.label}
+                </p>
+              )}
+              <div className="space-y-0.5">
+                {group.items.map(({ to, label, end }) => (
+                  <NavLink
+                    key={to}
+                    to={to}
+                    end={end}
+                    className={({ isActive }) =>
+                      `flex items-center px-3 py-2 rounded-md text-sm font-medium transition-colors ${
+                        isActive
+                          ? 'bg-primary text-primary-foreground'
+                          : 'text-muted-foreground hover:bg-accent hover:text-accent-foreground'
+                      }`
+                    }
+                  >
+                    {label}
+                  </NavLink>
+                ))}
+              </div>
+            </div>
           ))}
         </nav>
 

--- a/apps/web/src/pages/departments/DepartmentDetailPage.tsx
+++ b/apps/web/src/pages/departments/DepartmentDetailPage.tsx
@@ -26,14 +26,16 @@ export function DepartmentDetailPage() {
     description: '',
     headId: '',
   });
+  const [formReady, setFormReady] = useState(false);
 
   useEffect(() => {
     if (dept) {
       setForm({
         name: dept.name,
         description: dept.description ?? '',
-        headId: dept.headId ? String(dept.headId) : '',
+        headId: dept.headId != null ? String(dept.headId) : '',
       });
+      setFormReady(true);
     }
   }, [dept]);
 
@@ -42,7 +44,7 @@ export function DepartmentDetailPage() {
         ?.data?.message ?? 'Failed to update department.')
     : null;
 
-  if (deptQuery.isLoading || usersQuery.isLoading)
+  if (deptQuery.isLoading || usersQuery.isLoading || !formReady)
     return <div className="text-sm text-muted-foreground">Loading…</div>;
   if (deptQuery.isError || !dept)
     return (

--- a/apps/web/src/pages/positions/PositionDetailPage.tsx
+++ b/apps/web/src/pages/positions/PositionDetailPage.tsx
@@ -27,14 +27,16 @@ export function PositionDetailPage() {
     description: '',
     reportsToId: '',
   });
+  const [formReady, setFormReady] = useState(false);
 
   useEffect(() => {
     if (pos) {
       setForm({
         name: pos.name,
         description: pos.description ?? '',
-        reportsToId: pos.reportsToId ? String(pos.reportsToId) : '',
+        reportsToId: pos.reportsToId != null ? String(pos.reportsToId) : '',
       });
+      setFormReady(true);
     }
   }, [pos]);
 
@@ -43,7 +45,7 @@ export function PositionDetailPage() {
         ?.message ?? 'Failed to update position.')
     : null;
 
-  if (posQuery.isLoading || positionsQuery.isLoading)
+  if (posQuery.isLoading || positionsQuery.isLoading || !formReady)
     return <div className="text-sm text-muted-foreground">Loading…</div>;
   if (posQuery.isError || !pos)
     return <div className="text-sm text-destructive">Position not found.</div>;


### PR DESCRIPTION
## Summary

- Reorganize `AuthLayout` sidebar navigation into labeled groups: **Organization**, **Leave**, and **Admin** — improving scannability as the app grows
- Add `end` prop support to `NavItem` so `/leaves` matches exactly (prevents it staying active when on `/leaves/approvals`)
- Fix `headId` / `reportsToId` null check from falsy (`!value`) to strict (`!= null`) to correctly handle `0`-value IDs
- Add `formReady` flag to `DepartmentDetailPage` and `PositionDetailPage` to prevent stale/empty form state from flashing before data populates