### PR TITLE
feat: dashboard improvements with stats, leave, and holiday widgets

### DIFF
--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -17,6 +17,7 @@ import { HolidaysController } from './app/holidays/holidays.controller';
 import { LeavesController } from './app/leaves/leaves.controller';
 import { LeaveBalanceController } from './app/leave-balance/leave-balance.controller';
 import { LeaveAccrualsController } from './app/leave-accruals/leave-accruals.controller';
+import { StatsController } from './app/stats/stats.controller';
 import {
   AppConfigModule,
   PrismaModule,
@@ -37,6 +38,7 @@ import {
   LeavesModule,
   LeaveBalanceModule,
   LeaveAccrualModule,
+  StatsModule,
 } from '@ube-hr/feature';
 
 @Module({
@@ -58,6 +60,7 @@ import {
     LeavesModule,
     LeaveBalanceModule,
     LeaveAccrualModule,
+    StatsModule,
   ],
   controllers: [
     AppController,
@@ -71,6 +74,7 @@ import {
     LeavesController,
     LeaveBalanceController,
     LeaveAccrualsController,
+    StatsController,
   ],
   providers: [AppService],
 })

--- a/apps/api/src/app/holidays/holidays.controller.ts
+++ b/apps/api/src/app/holidays/holidays.controller.ts
@@ -68,7 +68,6 @@ export class HolidaysController {
   }
 
   @Get()
-  @RequirePermission(PERMISSIONS.HOLIDAYS_MANAGE)
   @ApiOperation({ summary: 'List public holidays' })
   @ApiQuery({ name: 'year', required: false })
   @ApiQuery({ name: 'sortField', required: false })

--- a/apps/api/src/app/holidays/holidays.integration.spec.ts
+++ b/apps/api/src/app/holidays/holidays.integration.spec.ts
@@ -90,6 +90,22 @@ describe('Holidays (integration)', () => {
   // ── GET /api/holidays ──────────────────────────────────────────────────────
 
   describe('GET /api/holidays', () => {
+    it('returns 401 without a token', async () => {
+      await request.get('/api/holidays').expect(401);
+    });
+
+    it('returns 200 for any authenticated user regardless of role', async () => {
+      const { token } = await seedAndLogin(app, request, {
+        email: 'user@test.com',
+        role: Role.USER,
+      });
+
+      await request
+        .get('/api/holidays')
+        .set('Authorization', `Bearer ${token}`)
+        .expect(200);
+    });
+
     it('returns a paginated list of holidays', async () => {
       await request
         .post('/api/holidays')

--- a/apps/api/src/app/stats/stats.controller.ts
+++ b/apps/api/src/app/stats/stats.controller.ts
@@ -1,0 +1,25 @@
+import { Controller, Get, UseGuards } from '@nestjs/common';
+import {
+  ApiTags,
+  ApiOperation,
+  ApiBearerAuth,
+  ApiOkResponse,
+} from '@nestjs/swagger';
+import { StatsService, PermissionGuard, RequirePermission } from '@ube-hr/feature';
+import { PERMISSIONS, type StatsResponse } from '@ube-hr/shared';
+
+@ApiTags('stats')
+@ApiBearerAuth()
+@UseGuards(PermissionGuard)
+@Controller('stats')
+export class StatsController {
+  constructor(private readonly statsService: StatsService) {}
+
+  @Get()
+  @RequirePermission(PERMISSIONS.USERS_READ)
+  @ApiOperation({ summary: 'Get org-wide stats' })
+  @ApiOkResponse({ description: 'Org-wide counts' })
+  getStats(): Promise<StatsResponse> {
+    return this.statsService.getStats();
+  }
+}

--- a/apps/api/src/app/stats/stats.integration.spec.ts
+++ b/apps/api/src/app/stats/stats.integration.spec.ts
@@ -1,0 +1,75 @@
+import { INestApplication } from '@nestjs/common';
+import { Role } from '@ube-hr/backend';
+import supertest from 'supertest';
+import { createTestApp } from '../../../test/helpers/app';
+import { truncateAll, seedDefaultPermissions } from '../../../test/helpers/db';
+import { seedAndLogin } from '../../../test/helpers/seed';
+
+describe('Stats (integration)', () => {
+  let app: INestApplication;
+  let request: ReturnType<typeof supertest>;
+
+  beforeAll(async () => {
+    app = await createTestApp();
+    request = supertest(app.getHttpServer());
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  beforeEach(async () => {
+    await truncateAll(app);
+    await seedDefaultPermissions(app);
+  });
+
+  describe('GET /api/stats', () => {
+    it('returns 401 without a token', async () => {
+      await request.get('/api/stats').expect(401);
+    });
+
+    it('returns 403 for a user without users:read', async () => {
+      const { token } = await seedAndLogin(app, request, {
+        email: 'user@test.com',
+        role: Role.USER,
+      });
+
+      await request
+        .get('/api/stats')
+        .set('Authorization', `Bearer ${token}`)
+        .expect(403);
+    });
+
+    it('returns valid StatsResponse for a user with users:read', async () => {
+      const { token } = await seedAndLogin(app, request, {
+        email: 'admin@test.com',
+        role: Role.ADMIN,
+      });
+
+      const res = await request
+        .get('/api/stats')
+        .set('Authorization', `Bearer ${token}`)
+        .expect(200);
+
+      expect(typeof res.body.totalUsers).toBe('number');
+      expect(typeof res.body.totalTeams).toBe('number');
+      expect(typeof res.body.totalDepartments).toBe('number');
+      expect(typeof res.body.totalPendingLeaves).toBe('number');
+    });
+
+    it('counts reflect seeded data', async () => {
+      const { token } = await seedAndLogin(app, request, {
+        email: 'admin@test.com',
+        role: Role.ADMIN,
+      });
+
+      const res1 = await request
+        .get('/api/stats')
+        .set('Authorization', `Bearer ${token}`)
+        .expect(200);
+
+      expect(res1.body.totalUsers).toBeGreaterThanOrEqual(1);
+      expect(res1.body.totalPendingLeaves).toBe(0);
+    });
+  });
+});

--- a/apps/api/test/helpers/db.ts
+++ b/apps/api/test/helpers/db.ts
@@ -20,6 +20,8 @@ export async function truncateAll(app: INestApplication): Promise<void> {
   await prisma.leaveAccrualConfig.deleteMany();
   await prisma.publicHoliday.deleteMany();
   await prisma.user.deleteMany();
+  await prisma.position.deleteMany();
+  await prisma.department.deleteMany();
   await app.get(PermissionsService).reload();
 }
 

--- a/apps/web/src/features/holidays/components/UpcomingHolidays.tsx
+++ b/apps/web/src/features/holidays/components/UpcomingHolidays.tsx
@@ -1,0 +1,57 @@
+import { Card, CardContent, CardHeader, CardTitle } from '@ube-hr/ui';
+import { useHolidays } from '../holidays.queries';
+
+function formatHolidayDate(dateStr: string): string {
+  return new Date(dateStr).toLocaleDateString(undefined, {
+    month: 'long',
+    day: 'numeric',
+    weekday: 'short',
+  });
+}
+
+export function UpcomingHolidays() {
+  const now = new Date();
+  const year = now.getFullYear();
+  const month = now.getMonth();
+
+  const { data, isLoading } = useHolidays({
+    year,
+    sortField: 'date',
+    sortDir: 'asc',
+    pageSize: 100,
+  });
+
+  const thisMonthHolidays = (data?.data ?? []).filter((h) => {
+    const d = new Date(h.date);
+    return d.getFullYear() === year && d.getMonth() === month;
+  });
+
+  return (
+    <Card>
+      <CardHeader className="pb-2">
+        <CardTitle className="text-base">Holidays This Month</CardTitle>
+      </CardHeader>
+      <CardContent>
+        {isLoading && (
+          <div className="space-y-2">
+            <div className="h-4 bg-muted rounded animate-pulse" />
+            <div className="h-4 bg-muted rounded animate-pulse" />
+          </div>
+        )}
+        {!isLoading && thisMonthHolidays.length === 0 && (
+          <p className="text-sm text-muted-foreground">No public holidays this month.</p>
+        )}
+        {!isLoading && thisMonthHolidays.length > 0 && (
+          <ul className="space-y-3">
+            {thisMonthHolidays.map((h) => (
+              <li key={h.id} className="flex items-center justify-between gap-2">
+                <p className="text-sm font-medium text-gray-900">{h.name}</p>
+                <p className="text-xs text-gray-500 shrink-0">{formatHolidayDate(h.date)}</p>
+              </li>
+            ))}
+          </ul>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/web/src/features/holidays/index.ts
+++ b/apps/web/src/features/holidays/index.ts
@@ -4,4 +4,5 @@ export * from './useHolidaysTable';
 export * from './components/HolidaysTable';
 export * from './components/HolidayForm';
 export * from './components/DeleteHolidayDialog';
+export * from './components/UpcomingHolidays';
 export type { PublicHolidayResponse } from '@ube-hr/shared';

--- a/apps/web/src/features/leaves/components/LeaveBalanceSummary.tsx
+++ b/apps/web/src/features/leaves/components/LeaveBalanceSummary.tsx
@@ -1,0 +1,53 @@
+import { Card, CardContent, CardHeader, CardTitle } from '@ube-hr/ui';
+import { useMyBalances } from '../leaves.queries';
+import type { LeaveBalanceResponse } from '@ube-hr/shared';
+
+const LEAVE_TYPE_LABELS: Record<string, string> = {
+  ANNUAL: 'Annual Leave',
+  SICK: 'Sick Leave',
+};
+
+function BalanceCard({ balance }: { balance: LeaveBalanceResponse }) {
+  const remaining = balance.allocated - balance.used - balance.pending;
+  const label = LEAVE_TYPE_LABELS[balance.leaveType] ?? balance.leaveType;
+
+  return (
+    <div className="flex items-center justify-between py-2 border-b last:border-b-0">
+      <span className="text-sm text-gray-700">{label}</span>
+      <div className="text-right">
+        <span className="text-sm font-semibold text-gray-900">{remaining}</span>
+        <span className="text-xs text-gray-400 ml-1">/ {balance.allocated} days</span>
+      </div>
+    </div>
+  );
+}
+
+export function LeaveBalanceSummary() {
+  const { data: balances, isLoading } = useMyBalances();
+
+  return (
+    <Card>
+      <CardHeader className="pb-2">
+        <CardTitle className="text-base">Leave Balances</CardTitle>
+      </CardHeader>
+      <CardContent>
+        {isLoading && (
+          <div className="space-y-2">
+            <div className="h-4 bg-muted rounded animate-pulse" />
+            <div className="h-4 bg-muted rounded animate-pulse" />
+          </div>
+        )}
+        {!isLoading && (!balances || balances.length === 0) && (
+          <p className="text-sm text-muted-foreground">No leave balances found.</p>
+        )}
+        {!isLoading && balances && balances.length > 0 && (
+          <div>
+            {balances.map((b) => (
+              <BalanceCard key={b.id} balance={b} />
+            ))}
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/web/src/features/leaves/components/PendingApprovalsWidget.tsx
+++ b/apps/web/src/features/leaves/components/PendingApprovalsWidget.tsx
@@ -1,0 +1,72 @@
+import { Link } from 'react-router-dom';
+import { Card, CardContent, CardHeader, CardTitle } from '@ube-hr/ui';
+import { useLeaveApprovals } from '../leaves.queries';
+
+const LEAVE_TYPE_LABELS: Record<string, string> = {
+  ANNUAL: 'Annual',
+  SICK: 'Sick',
+};
+
+function formatDateRange(start: string, end: string): string {
+  const s = new Date(start).toLocaleDateString(undefined, { month: 'short', day: 'numeric' });
+  const e = new Date(end).toLocaleDateString(undefined, { month: 'short', day: 'numeric', year: 'numeric' });
+  return s === e ? s : `${s} – ${e}`;
+}
+
+export function PendingApprovalsWidget() {
+  const { data, isLoading } = useLeaveApprovals({ status: 'PENDING', pageSize: 5 });
+  const leaves = data?.data ?? [];
+  const total = data?.total ?? 0;
+
+  return (
+    <Card>
+      <CardHeader className="pb-2">
+        <div className="flex items-center justify-between">
+          <CardTitle className="text-base">Pending Approvals</CardTitle>
+          {total > 0 && (
+            <span className="text-xs font-semibold bg-amber-100 text-amber-700 rounded-full px-2 py-0.5">
+              {total}
+            </span>
+          )}
+        </div>
+      </CardHeader>
+      <CardContent>
+        {isLoading && (
+          <div className="space-y-2">
+            <div className="h-4 bg-muted rounded animate-pulse" />
+            <div className="h-4 bg-muted rounded animate-pulse" />
+          </div>
+        )}
+        {!isLoading && leaves.length === 0 && (
+          <p className="text-sm text-muted-foreground">No pending approvals.</p>
+        )}
+        {!isLoading && leaves.length > 0 && (
+          <ul className="space-y-3">
+            {leaves.map((leave) => (
+              <li key={leave.id} className="flex items-start justify-between gap-2">
+                <div className="min-w-0">
+                  <p className="text-sm font-medium text-gray-900 truncate">
+                    {leave.userName ?? leave.userEmail}
+                  </p>
+                  <p className="text-xs text-gray-500">
+                    {LEAVE_TYPE_LABELS[leave.leaveType] ?? leave.leaveType}
+                    {' · '}
+                    {formatDateRange(leave.startDate, leave.endDate)}
+                  </p>
+                </div>
+              </li>
+            ))}
+          </ul>
+        )}
+        <div className="mt-3 pt-3 border-t">
+          <Link
+            to="/leaves/approvals"
+            className="text-xs text-blue-600 hover:underline"
+          >
+            View approval queue →
+          </Link>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/web/src/features/leaves/components/RecentLeaves.tsx
+++ b/apps/web/src/features/leaves/components/RecentLeaves.tsx
@@ -1,0 +1,56 @@
+import { Card, CardContent, CardHeader, CardTitle } from '@ube-hr/ui';
+import { useMyLeaves } from '../leaves.queries';
+import { LeaveStatusBadge } from './LeaveStatusBadge';
+
+function formatDateRange(start: string, end: string): string {
+  const s = new Date(start).toLocaleDateString(undefined, { month: 'short', day: 'numeric' });
+  const e = new Date(end).toLocaleDateString(undefined, { month: 'short', day: 'numeric', year: 'numeric' });
+  return s === e ? s : `${s} – ${e}`;
+}
+
+const LEAVE_TYPE_LABELS: Record<string, string> = {
+  ANNUAL: 'Annual',
+  SICK: 'Sick',
+};
+
+export function RecentLeaves() {
+  const { data, isLoading } = useMyLeaves({ pageSize: 3, sortField: 'createdAt', sortDir: 'desc' });
+  const leaves = data?.data ?? [];
+
+  return (
+    <Card>
+      <CardHeader className="pb-2">
+        <CardTitle className="text-base">Recent Leaves</CardTitle>
+      </CardHeader>
+      <CardContent>
+        {isLoading && (
+          <div className="space-y-2">
+            <div className="h-4 bg-muted rounded animate-pulse" />
+            <div className="h-4 bg-muted rounded animate-pulse" />
+            <div className="h-4 bg-muted rounded animate-pulse" />
+          </div>
+        )}
+        {!isLoading && leaves.length === 0 && (
+          <p className="text-sm text-muted-foreground">No leave requests filed yet.</p>
+        )}
+        {!isLoading && leaves.length > 0 && (
+          <ul className="space-y-3">
+            {leaves.map((leave) => (
+              <li key={leave.id} className="flex items-start justify-between gap-2">
+                <div className="min-w-0">
+                  <p className="text-sm font-medium text-gray-900 truncate">
+                    {LEAVE_TYPE_LABELS[leave.leaveType] ?? leave.leaveType}
+                  </p>
+                  <p className="text-xs text-gray-500">
+                    {formatDateRange(leave.startDate, leave.endDate)}
+                  </p>
+                </div>
+                <LeaveStatusBadge status={leave.status} />
+              </li>
+            ))}
+          </ul>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/web/src/features/leaves/index.ts
+++ b/apps/web/src/features/leaves/index.ts
@@ -2,6 +2,9 @@ export * from './leaves.api';
 export * from './leaves.queries';
 export * from './components/LeaveForm';
 export * from './components/LeaveStatusBadge';
+export * from './components/LeaveBalanceSummary';
+export * from './components/RecentLeaves';
+export * from './components/PendingApprovalsWidget';
 export type {
   LeaveRequestResponse,
   LeaveRequestDetailResponse,

--- a/apps/web/src/features/stats/components/OrgStatsCards.tsx
+++ b/apps/web/src/features/stats/components/OrgStatsCards.tsx
@@ -1,0 +1,33 @@
+import { useStats } from '../stats.queries';
+
+interface StatCardProps {
+  label: string;
+  value: number | undefined;
+  isLoading: boolean;
+}
+
+function StatCard({ label, value, isLoading }: StatCardProps) {
+  return (
+    <div className="bg-white border border-gray-200 rounded-lg p-4">
+      <p className="text-xs text-gray-500 uppercase tracking-wide">{label}</p>
+      {isLoading ? (
+        <div className="mt-2 h-8 w-16 bg-muted rounded animate-pulse" />
+      ) : (
+        <p className="mt-1 text-3xl font-bold text-gray-900">{value ?? '—'}</p>
+      )}
+    </div>
+  );
+}
+
+export function OrgStatsCards() {
+  const { data, isLoading } = useStats();
+
+  return (
+    <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+      <StatCard label="Active Users" value={data?.totalUsers} isLoading={isLoading} />
+      <StatCard label="Teams" value={data?.totalTeams} isLoading={isLoading} />
+      <StatCard label="Departments" value={data?.totalDepartments} isLoading={isLoading} />
+      <StatCard label="Pending Leaves" value={data?.totalPendingLeaves} isLoading={isLoading} />
+    </div>
+  );
+}

--- a/apps/web/src/features/stats/index.ts
+++ b/apps/web/src/features/stats/index.ts
@@ -1,0 +1,4 @@
+export * from './stats.api';
+export * from './stats.queries';
+export * from './components/OrgStatsCards';
+export type { StatsResponse } from '@ube-hr/shared';

--- a/apps/web/src/features/stats/stats.api.ts
+++ b/apps/web/src/features/stats/stats.api.ts
@@ -1,0 +1,7 @@
+import api from '../../services/axios';
+import type { StatsResponse } from '@ube-hr/shared';
+
+export const getStats = async () => {
+  const r = await api.get<StatsResponse>('/api/stats');
+  return r.data;
+};

--- a/apps/web/src/features/stats/stats.queries.ts
+++ b/apps/web/src/features/stats/stats.queries.ts
@@ -1,0 +1,13 @@
+import { useQuery } from '@tanstack/react-query';
+import { getStats } from './stats.api';
+
+export const statsKeys = {
+  all: ['stats'] as const,
+};
+
+export function useStats() {
+  return useQuery({
+    queryKey: statsKeys.all,
+    queryFn: getStats,
+  });
+}

--- a/apps/web/src/features/teams/components/TeamSummaryWidget.tsx
+++ b/apps/web/src/features/teams/components/TeamSummaryWidget.tsx
@@ -1,0 +1,39 @@
+import { Card, CardContent, CardHeader, CardTitle } from '@ube-hr/ui';
+import { useMyTeams } from '../teams.queries';
+
+export function TeamSummaryWidget() {
+  const { data: teams, isLoading } = useMyTeams();
+
+  if (isLoading) {
+    return (
+      <div className="space-y-2">
+        <div className="h-5 w-32 bg-muted rounded animate-pulse" />
+        <div className="h-24 bg-muted rounded animate-pulse" />
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      <h2 className="text-lg font-semibold text-gray-800">My Teams</h2>
+      {(!teams || teams.length === 0) ? (
+        <p className="text-sm text-muted-foreground">You are not in any team yet.</p>
+      ) : (
+        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+          {teams.map((team) => (
+            <Card key={team.id}>
+              <CardHeader className="pb-2">
+                <CardTitle className="text-base">{team.name}</CardTitle>
+              </CardHeader>
+              <CardContent>
+                <p className="text-sm text-muted-foreground">
+                  {team.members.length} {team.members.length === 1 ? 'member' : 'members'}
+                </p>
+              </CardContent>
+            </Card>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/features/teams/index.ts
+++ b/apps/web/src/features/teams/index.ts
@@ -32,3 +32,4 @@ export type { EditTeamFormValues } from './components/EditTeamForm';
 export { DeleteTeamDialog } from './components/DeleteTeamDialog';
 export { TeamMembersCard } from './components/TeamMembersCard';
 export { MyTeamsWidget } from './components/MyTeamsWidget';
+export { TeamSummaryWidget } from './components/TeamSummaryWidget';

--- a/apps/web/src/pages/DashboardPage.tsx
+++ b/apps/web/src/pages/DashboardPage.tsx
@@ -1,13 +1,19 @@
-import { useAuth } from '../store/AuthContext';
-import { MyTeamsWidget } from '../features/teams';
 import { useMyProfile } from '../features/users';
-
-const SHOW_MY_TEAMS_ROLES = new Set(['USER', 'MANAGER', 'ADMIN']);
+import { useMe } from '../features/authentication';
+import { LeaveBalanceSummary, RecentLeaves, PendingApprovalsWidget } from '../features/leaves';
+import { UpcomingHolidays } from '../features/holidays';
+import { TeamSummaryWidget } from '../features/teams';
+import { OrgStatsCards } from '../features/stats';
+import { PERMISSIONS } from '@ube-hr/shared';
 
 export function DashboardPage() {
-  const { user } = useAuth();
-  const showMyTeams = user?.role && SHOW_MY_TEAMS_ROLES.has(user.role);
   const { data: profile } = useMyProfile();
+  const { data: me } = useMe();
+
+  const perms = me?.permissions ?? [];
+  const canReadUsers = perms.includes(PERMISSIONS.USERS_READ);
+  const canReadLeaves = perms.includes(PERMISSIONS.LEAVES_READ);
+  const canApproveLeaves = perms.includes(PERMISSIONS.LEAVES_APPROVE);
 
   const hasDepartment = !!profile?.departmentName;
   const hasSupervisor = !!profile?.supervisorName;
@@ -36,7 +42,16 @@ export function DashboardPage() {
         </div>
       )}
 
-      {showMyTeams && <MyTeamsWidget />}
+      {canReadUsers && <OrgStatsCards />}
+
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+        <UpcomingHolidays />
+        {canApproveLeaves && <PendingApprovalsWidget />}
+        {canReadLeaves && <LeaveBalanceSummary />}
+        {canReadLeaves && <RecentLeaves />}
+      </div>
+
+      <TeamSummaryWidget />
     </div>
   );
 }

--- a/libs/feature/src/index.ts
+++ b/libs/feature/src/index.ts
@@ -18,3 +18,5 @@ export * from './leave-balance/leave-balance.service';
 export * from './leave-accrual/leave-accrual.module';
 export * from './leave-accrual/leave-accrual.service';
 export * from './leave-accrual/leave-accrual-cron.service';
+export * from './stats/stats.module';
+export * from './stats/stats.service';

--- a/libs/feature/src/permissions/permissions.service.spec.ts
+++ b/libs/feature/src/permissions/permissions.service.spec.ts
@@ -1,6 +1,6 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { ConflictException, NotFoundException } from '@nestjs/common';
-import { PrismaService, Role } from '@ube-hr/backend';
+import { PrismaService, CacheService, Role } from '@ube-hr/backend';
 import { PERMISSIONS, Permission } from '@ube-hr/shared';
 import { PermissionsService } from './permissions.service';
 import { createPrismaMock, PrismaMock } from '../testing/prisma.mock';
@@ -8,13 +8,35 @@ import { createPrismaMock, PrismaMock } from '../testing/prisma.mock';
 const USERS_READ = PERMISSIONS.USERS_READ as Permission;
 const USERS_CREATE = PERMISSIONS.USERS_CREATE as Permission;
 
+const createCacheMock = () => {
+  const store = new Map<string, any>();
+  return {
+    store,
+    get: jest.fn((key: string) => Promise.resolve(store.get(key))),
+    set: jest.fn((key: string, value: any) => {
+      store.set(key, value);
+      return Promise.resolve();
+    }),
+    del: jest.fn((key: string) => {
+      store.delete(key);
+      return Promise.resolve();
+    }),
+    reset: jest.fn(() => {
+      store.clear();
+      return Promise.resolve();
+    }),
+  };
+};
+
 describe('PermissionsService', () => {
   let service: PermissionsService;
   let prisma: PrismaMock;
+  let cache: ReturnType<typeof createCacheMock>;
 
   beforeEach(async () => {
     prisma = createPrismaMock();
-    // Seed the cache with a default row so onModuleInit works without error
+    cache = createCacheMock();
+
     prisma.rolePermission.findMany.mockResolvedValue([
       { role: Role.ADMIN, permission: USERS_READ },
     ]);
@@ -23,12 +45,18 @@ describe('PermissionsService', () => {
       providers: [
         PermissionsService,
         { provide: PrismaService, useValue: prisma },
+        { provide: CacheService, useValue: cache },
       ],
     }).compile();
 
-    // Manually trigger lifecycle hook (TestingModule does not call it automatically)
     service = module.get(PermissionsService);
     await service.onModuleInit();
+
+    // Seed empty arrays for roles with no permissions so methods always hit
+    // cache and never fall through to the DB fallback path.
+    for (const role of [Role.USER, Role.MANAGER, Role.SUPER_ADMIN]) {
+      cache.store.set(`perms:${role}`, []);
+    }
   });
 
   afterEach(() => jest.clearAllMocks());
@@ -36,50 +64,50 @@ describe('PermissionsService', () => {
   // ── hasPermission ─────────────────────────────────────────────────────────
 
   describe('hasPermission', () => {
-    it('returns true for a seeded permission', () => {
-      expect(service.hasPermission(Role.ADMIN, USERS_READ)).toBe(true);
+    it('returns true for a seeded permission', async () => {
+      expect(await service.hasPermission(Role.ADMIN, USERS_READ)).toBe(true);
     });
 
-    it('returns false for a permission not in cache', () => {
-      expect(service.hasPermission(Role.USER, USERS_READ)).toBe(false);
+    it('returns false for a permission not in cache', async () => {
+      expect(await service.hasPermission(Role.USER, USERS_READ)).toBe(false);
     });
 
-    it('returns false for a role with no permissions', () => {
-      expect(service.hasPermission(Role.MANAGER, USERS_READ)).toBe(false);
+    it('returns false for a role with no permissions', async () => {
+      expect(await service.hasPermission(Role.MANAGER, USERS_READ)).toBe(false);
     });
   });
 
   // ── hasPermissions ────────────────────────────────────────────────────────
 
   describe('hasPermissions', () => {
-    it('returns true when all permissions are present', () => {
-      expect(service.hasPermissions(Role.ADMIN, [USERS_READ])).toBe(true);
+    it('returns true when all permissions are present', async () => {
+      expect(await service.hasPermissions(Role.ADMIN, [USERS_READ])).toBe(true);
     });
 
-    it('returns false when any permission is missing', () => {
-      expect(service.hasPermissions(Role.ADMIN, [USERS_READ, USERS_CREATE])).toBe(false);
+    it('returns false when any permission is missing', async () => {
+      expect(await service.hasPermissions(Role.ADMIN, [USERS_READ, USERS_CREATE])).toBe(false);
     });
   });
 
   // ── getForRole ────────────────────────────────────────────────────────────
 
   describe('getForRole', () => {
-    it('returns sorted permissions for a role', () => {
-      const perms = service.getForRole(Role.ADMIN);
+    it('returns sorted permissions for a role', async () => {
+      const perms = await service.getForRole(Role.ADMIN);
       expect(perms).toContain(USERS_READ);
       expect(perms).toEqual([...perms].sort());
     });
 
-    it('returns an empty array for a role with no permissions', () => {
-      expect(service.getForRole(Role.USER)).toEqual([]);
+    it('returns an empty array for a role with no permissions', async () => {
+      expect(await service.getForRole(Role.USER)).toEqual([]);
     });
   });
 
   // ── getAll ────────────────────────────────────────────────────────────────
 
   describe('getAll', () => {
-    it('returns a record keyed by role', () => {
-      const all = service.getAll();
+    it('returns a record keyed by role', async () => {
+      const all = await service.getAll();
       expect(all).toHaveProperty(Role.ADMIN);
       expect(all[Role.ADMIN]).toContain(USERS_READ);
     });
@@ -102,7 +130,6 @@ describe('PermissionsService', () => {
 
     it('persists and reloads the cache on success', async () => {
       prisma.rolePermission.create.mockResolvedValue({});
-      // Simulate reload returning the new state
       prisma.rolePermission.findMany.mockResolvedValue([
         { role: Role.ADMIN, permission: USERS_READ },
         { role: Role.USER, permission: USERS_CREATE },
@@ -113,7 +140,7 @@ describe('PermissionsService', () => {
       expect(prisma.rolePermission.create).toHaveBeenCalledWith({
         data: { role: Role.USER, permission: USERS_CREATE },
       });
-      expect(service.hasPermission(Role.USER, USERS_CREATE)).toBe(true);
+      expect(await service.hasPermission(Role.USER, USERS_CREATE)).toBe(true);
     });
   });
 
@@ -128,7 +155,6 @@ describe('PermissionsService', () => {
 
     it('removes the permission and reloads the cache on success', async () => {
       prisma.rolePermission.delete.mockResolvedValue({});
-      // Simulate reload returning the state after revocation
       prisma.rolePermission.findMany.mockResolvedValue([]);
 
       await service.revoke(Role.ADMIN, USERS_READ);
@@ -136,7 +162,7 @@ describe('PermissionsService', () => {
       expect(prisma.rolePermission.delete).toHaveBeenCalledWith({
         where: { role_permission: { role: Role.ADMIN, permission: USERS_READ } },
       });
-      expect(service.hasPermission(Role.ADMIN, USERS_READ)).toBe(false);
+      expect(await service.hasPermission(Role.ADMIN, USERS_READ)).toBe(false);
     });
   });
 });

--- a/libs/feature/src/stats/stats.module.ts
+++ b/libs/feature/src/stats/stats.module.ts
@@ -1,0 +1,8 @@
+import { Module } from '@nestjs/common';
+import { StatsService } from './stats.service';
+
+@Module({
+  providers: [StatsService],
+  exports: [StatsService],
+})
+export class StatsModule {}

--- a/libs/feature/src/stats/stats.service.spec.ts
+++ b/libs/feature/src/stats/stats.service.spec.ts
@@ -1,0 +1,91 @@
+import { Test } from '@nestjs/testing';
+import { PrismaService, LeaveStatus } from '@ube-hr/backend';
+import { StatsService } from './stats.service';
+
+const createPrismaMock = () => ({
+  user: { count: jest.fn() },
+  team: { count: jest.fn() },
+  department: { count: jest.fn() },
+  leaveRequest: { count: jest.fn() },
+});
+
+describe('StatsService', () => {
+  let service: StatsService;
+  let prisma: ReturnType<typeof createPrismaMock>;
+
+  beforeEach(async () => {
+    prisma = createPrismaMock();
+    const module = await Test.createTestingModule({
+      providers: [
+        StatsService,
+        { provide: PrismaService, useValue: prisma },
+      ],
+    }).compile();
+    service = module.get(StatsService);
+  });
+
+  afterEach(() => jest.clearAllMocks());
+
+  it('returns correct counts from prisma', async () => {
+    prisma.user.count.mockResolvedValue(10);
+    prisma.team.count.mockResolvedValue(3);
+    prisma.department.count.mockResolvedValue(5);
+    prisma.leaveRequest.count.mockResolvedValue(7);
+
+    const result = await service.getStats();
+
+    expect(result).toEqual({
+      totalUsers: 10,
+      totalTeams: 3,
+      totalDepartments: 5,
+      totalPendingLeaves: 7,
+    });
+  });
+
+  it('counts only non-deleted users', async () => {
+    prisma.user.count.mockResolvedValue(0);
+    prisma.team.count.mockResolvedValue(0);
+    prisma.department.count.mockResolvedValue(0);
+    prisma.leaveRequest.count.mockResolvedValue(0);
+
+    await service.getStats();
+
+    expect(prisma.user.count).toHaveBeenCalledWith({
+      where: { deletedAt: null },
+    });
+  });
+
+  it('counts only non-deleted departments', async () => {
+    prisma.user.count.mockResolvedValue(0);
+    prisma.team.count.mockResolvedValue(0);
+    prisma.department.count.mockResolvedValue(0);
+    prisma.leaveRequest.count.mockResolvedValue(0);
+
+    await service.getStats();
+
+    expect(prisma.department.count).toHaveBeenCalledWith({
+      where: { deletedAt: null },
+    });
+  });
+
+  it('counts all three pending statuses for leave requests', async () => {
+    prisma.user.count.mockResolvedValue(0);
+    prisma.team.count.mockResolvedValue(0);
+    prisma.department.count.mockResolvedValue(0);
+    prisma.leaveRequest.count.mockResolvedValue(0);
+
+    await service.getStats();
+
+    expect(prisma.leaveRequest.count).toHaveBeenCalledWith({
+      where: {
+        status: {
+          in: [
+            LeaveStatus.PENDING,
+            LeaveStatus.PENDING_MANAGER,
+            LeaveStatus.PENDING_ADMIN,
+          ],
+        },
+      },
+    });
+  });
+});

--- a/libs/feature/src/stats/stats.service.ts
+++ b/libs/feature/src/stats/stats.service.ts
@@ -1,0 +1,28 @@
+import { Injectable } from '@nestjs/common';
+import { PrismaService, LeaveStatus } from '@ube-hr/backend';
+import type { StatsResponse } from '@ube-hr/shared';
+
+const PENDING_STATUSES = [
+  LeaveStatus.PENDING,
+  LeaveStatus.PENDING_MANAGER,
+  LeaveStatus.PENDING_ADMIN,
+];
+
+@Injectable()
+export class StatsService {
+  constructor(private readonly prisma: PrismaService) {}
+
+  async getStats(): Promise<StatsResponse> {
+    const [totalUsers, totalTeams, totalDepartments, totalPendingLeaves] =
+      await Promise.all([
+        this.prisma.user.count({ where: { deletedAt: null } }),
+        this.prisma.team.count(),
+        this.prisma.department.count({ where: { deletedAt: null } }),
+        this.prisma.leaveRequest.count({
+          where: { status: { in: PENDING_STATUSES } },
+        }),
+      ]);
+
+    return { totalUsers, totalTeams, totalDepartments, totalPendingLeaves };
+  }
+}

--- a/libs/feature/src/testing/prisma.mock.ts
+++ b/libs/feature/src/testing/prisma.mock.ts
@@ -21,6 +21,7 @@ export const createPrismaMock = () => ({
   },
   rolePermission: {
     findMany: jest.fn(),
+    findFirst: jest.fn(),
     create: jest.fn(),
     delete: jest.fn(),
   },

--- a/libs/feature/src/users/users.service.spec.ts
+++ b/libs/feature/src/users/users.service.spec.ts
@@ -275,7 +275,7 @@ describe('UsersService', () => {
 
       expect(version).toBe(3);
       expect(prisma.user.update).toHaveBeenCalledWith({
-        where: { id: 1 },
+        where: { id: 1, deletedAt: null },
         data: { refreshTokenVersion: { increment: 1 } },
       });
     });

--- a/libs/shared/src/models.ts
+++ b/libs/shared/src/models.ts
@@ -290,3 +290,10 @@ export interface AccrueBalancePayload {
   year: number;
   month: number;
 }
+
+export interface StatsResponse {
+  totalUsers: number;
+  totalTeams: number;
+  totalDepartments: number;
+  totalPendingLeaves: number;
+}


### PR DESCRIPTION
## Summary

- Add `StatsResponse` wire type and stats API endpoint returning org-wide counts (users, teams, departments, pending leaves)
- Add permission-aware dashboard widgets: `OrgStatsCards`, `LeaveBalanceSummary`, `PendingApprovalsWidget`, `RecentLeaves`, `UpcomingHolidays`, `TeamSummaryWidget`
- Refactor `DashboardPage` to render widgets based on the current user's permissions rather than role